### PR TITLE
Ensure circle runs both rspec and rubocop

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   ruby:
     version: 2.4.0
 
+test:
+  override:
+    - bundle exec rake
+
 deployment:
   staging:
     branch: master


### PR DESCRIPTION
I guess the CircleCI default is to run this:

```
$ bundle exec rspec --color --require spec_helper spec --format progress
```

Which is totally sensible, but for some reason I had assumed it would
run the default rake task. In any event, this commit will ensure that
Circle runs our linter too.