### PR TITLE
Update Rspec config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---require spec_helper
+--order random


### PR DESCRIPTION
No need to explicitly require the spec helper - that's done for you. The random order is nice because it helps you discover tests that are order-dependent.