### PR TITLE
Back up and migrate db on deployment

### DIFF
--- a/script/heroku_deploy
+++ b/script/heroku_deploy
@@ -4,5 +4,7 @@ APP_NAME=$1
 
 git remote add heroku git@heroku.com:$APP_NAME.git
 git fetch heroku
+heroku pg:backups:capture
 git push heroku $CIRCLE_SHA1:master
-heroku restart --app $APP_NAME
+heroku run rake db:migrate
+heroku restart


### PR DESCRIPTION
I don't think you need to specify the `app` argument when you have a
remote named `heroku`, so I'm removing that too.