### PR TITLE
Simplify locations

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,4 @@
 class Location < ApplicationRecord
-  validates :address1, presence: true
+  validates :content, presence: true
   has_paper_trail ignore: [:created_at, :updated_at]
 end

--- a/db/migrate/20170223214056_simplify_locations.rb
+++ b/db/migrate/20170223214056_simplify_locations.rb
@@ -1,0 +1,14 @@
+class SimplifyLocations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :locations, :content, :string
+    remove_column :locations, :address1, :string
+    remove_column :locations, :address2, :string
+    remove_column :locations, :locality, :string
+    remove_column :locations, :region, :string
+    remove_column :locations, :postcode, :string
+    remove_column :locations, :country, :string
+
+    rename_column :locations, :lat, :latitude
+    rename_column :locations, :lng, :longitude
+  end
+end

--- a/spec/fabricators/location_fabricator.rb
+++ b/spec/fabricators/location_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator :location do
-  address1 { Fabricate.sequence(:address1) { |i| "Street address ##{i}" } }
+  content '123 Main Street, New York, NY 10001'
 end


### PR DESCRIPTION
@gnilekaw and I realized today that we could simplify the locations
table by reducing it to just the string of the address. While I was at
it, I renamed the lat/long columns to their full names. I prefer to
spell things out when possible - hope that's ok!