### PR TITLE
Add support for csv uploads adding org data

### DIFF
--- a/app/jobs/raw_input_transform_job.rb
+++ b/app/jobs/raw_input_transform_job.rb
@@ -1,14 +1,7 @@
 class RawInputTransformJob < ActiveJob::Base
   def perform(raw_input_id)
-    raw_input = RawInput.find(raw_input_id)
-    attrs = raw_input.transform
-
-    PaperTrail.with_actor(raw_input) do
-      organization = Organization.create
-      organization.locations.create attrs[:location]
-      organization.organization_names.create attrs[:organization_name]
-      organization.websites.create attrs[:website]
-      raw_input.record_result 'created', organization
-    end
+    raw_input = RawInput.find_by id: raw_input_id
+    return unless raw_input
+    RawInputChanges.apply raw_input
   end
 end

--- a/app/models/raw_input_changes.rb
+++ b/app/models/raw_input_changes.rb
@@ -1,0 +1,54 @@
+class RawInputChanges
+  def self.apply(raw_input)
+    new(raw_input).apply
+  end
+
+  def initialize(raw_input)
+    @raw_input = raw_input
+    @attrs = raw_input.transform
+  end
+
+  def apply
+    if matching_organization
+      update_organization
+    else
+      create_organization
+    end
+  end
+
+  private
+
+  def url
+    @attrs.fetch(:website, {})[:content]
+  end
+
+  def matching_website
+    @matching_website ||= Website.find_by(content: url)
+  end
+
+  def matching_organization
+    matching_website&.organization
+  end
+
+  def update_organization
+    PaperTrail.with_actor(@raw_input) do
+      matching_organization.locations.create @attrs[:location]
+      matching_organization.organization_names.create @attrs[:organization_name]
+    end
+
+    @raw_input.record_result 'updated', matching_organization
+  end
+
+  def create_organization
+    organization = nil
+
+    PaperTrail.with_actor(@raw_input) do
+      organization = Organization.create
+      organization.locations.create @attrs[:location]
+      organization.organization_names.create @attrs[:organization_name]
+      organization.websites.create @attrs[:website]
+    end
+
+    @raw_input.record_result 'created', organization
+  end
+end

--- a/spec/jobs/raw_input_transform_job_spec.rb
+++ b/spec/jobs/raw_input_transform_job_spec.rb
@@ -2,43 +2,18 @@ require 'rails_helper'
 
 describe RawInputTransformJob do
   describe '#perform' do
-    context 'with a new record' do
-      it 'creates that record and records the result' do
-        source = Fabricate :source
-        import = Fabricate(:import,
-                           source: source,
-                           transformer: CsvTransformer)
-        data = {
-          location: '123 Main Street, New York, NY 10001',
-          latitude: '47.5543105',
-          longitude: '7.598538899999999',
-          organization_name: 'Best Gallery',
-          website: 'http://example.com'
-        }
-        raw_input = Fabricate :raw_input, import: import, data: data
+    context 'with a valid raw_input id' do
+      it 'applies the raw_input changes' do
+        raw_input = Fabricate :raw_input
+        expect(RawInputChanges).to receive(:apply).with(raw_input)
         RawInputTransformJob.new.perform raw_input.id
+      end
+    end
 
-        expect(Organization.count).to eq 1
-        organization = Organization.first
-        expect(organization.versions.first.actor).to eq raw_input
-
-        expect(Location.count).to eq 1
-        location = Location.first
-        expect(location.versions.first.actor).to eq raw_input
-
-        expect(Website.count).to eq 1
-        website = Location.first
-        expect(website.versions.first.actor).to eq raw_input
-
-        expect(OrganizationName.count).to eq 1
-        name = OrganizationName.first
-        expect(name.versions.first.actor).to eq raw_input
-
-        expect(raw_input.reload.output_id).to eq organization.id
-        expect(raw_input.output_type).to eq organization.class.to_s
-        expect(raw_input.result).to eq 'created'
-
-        expect(PaperTrail.whodunnit).to eq 'Test User'
+    context 'with an invalid raw_input id' do
+      it 'returns early' do
+        expect(RawInputChanges).to_not receive(:apply)
+        RawInputTransformJob.new.perform nil
       end
     end
   end

--- a/spec/models/raw_input_changes_spec.rb
+++ b/spec/models/raw_input_changes_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe RawInputChanges do
+  describe '.apply' do
+    context 'with a new organization' do
+      it 'creates that organization and records the result' do
+        source = Fabricate :source
+        import = Fabricate(:import,
+                           source: source,
+                           transformer: CsvTransformer)
+        data = {
+          location: '123 Main Street, New York, NY 10001',
+          latitude: '47.5543105',
+          longitude: '7.598538899999999',
+          organization_name: 'Best Gallery',
+          website: 'http://example.com'
+        }
+        raw_input = Fabricate :raw_input, import: import, data: data
+        RawInputChanges.apply raw_input
+
+        expect(Organization.count).to eq 1
+        organization = Organization.first
+        expect(organization.versions.first.actor).to eq raw_input
+
+        expect(Location.count).to eq 1
+        location = Location.first
+        expect(location.versions.first.actor).to eq raw_input
+
+        expect(Website.count).to eq 1
+        website = Location.first
+        expect(website.versions.first.actor).to eq raw_input
+
+        expect(OrganizationName.count).to eq 1
+        name = OrganizationName.first
+        expect(name.versions.first.actor).to eq raw_input
+
+        expect(raw_input.reload.output_id).to eq organization.id
+        expect(raw_input.output_type).to eq organization.class.to_s
+        expect(raw_input.result).to eq 'created'
+
+        expect(PaperTrail.whodunnit).to eq 'Test User'
+      end
+    end
+
+    context 'with an existing organization' do
+      it 'updates that organization with more data' do
+        website = 'http://example.com'
+        organization = Fabricate :organization
+        Fabricate :website, organization: organization, content: website
+
+        source = Fabricate :source
+        import = Fabricate(:import,
+                           source: source,
+                           transformer: CsvTransformer)
+        data = {
+          location: '123 Main Street, New York, NY 10001',
+          latitude: '47.5543105',
+          longitude: '7.598538899999999',
+          organization_name: 'Best Gallery',
+          website: website
+        }
+        raw_input = Fabricate :raw_input, import: import, data: data
+        RawInputChanges.apply raw_input
+
+        expect(Organization.count).to eq 1
+
+        expect(organization.locations.count).to eq 1
+        expect(organization.websites.count).to eq 1
+        expect(organization.organization_names.count).to eq 1
+
+        expect(raw_input.reload.output_id).to eq organization.id
+        expect(raw_input.output_type).to eq organization.class.to_s
+        expect(raw_input.result).to eq 'updated'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for importing more data into an existing
organization using the csv import rake task. What will happen is that
when a website match is found, we'll create additional location and
organization names. This is still very naive, but it's moving us in the
right direction.

I think you know you're headed in the right direction when the commit
you're working on simplifies an `ActiveJob` class to look more like a
controller. I knew that I wanted to extract a class to do the work of
either updating or creating an organization, but I had a really hard
time coming up with a name for it.

What I settled on was `RawInputChanges` with a public API called
`apply`. Totally open to ideas here, but that's what sounded natural to
me.

I'll also note here that with this extraction done, I've also moved the
tests about what happens under different scenarios to the extracted
class and kept the specs for the actual job really light - just about
the couple cases it could face. This felt like a win too.