### PR TITLE
Add script to automate deployment

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# get project name
+project=$(git remote show upstream | grep Fetch | cut -d ':' -f 3 | cut -d '.' -f 1)
+
+# show included PRs
+prs=$(git log upstream/release...upstream/master --merges --oneline | cut -d ' ' -f 5 | cut -d '#' -f 2)
+
+body="Included PRs:\n\n"
+for pr in $prs; do
+  body="$body* #$pr\n"
+  echo https://github.com/$project/issues/$pr
+done
+
+# ask for title
+read -p 'title: ' title
+
+# create deploy PR
+message="Deploy: $title\n\n$body"
+echo $message | hub pull-request -b $project:release -h $project:master -F -


### PR DESCRIPTION
While deploying vibrations this morning, I realized that there are some things that could easily be automated about our deployment process. This script is my first effort on addressing this. The idea is that if you're fetched upstream, then you'd be able to run this script to create a deploy PR with a list of the PRs that make up the deployment.

I did take the time to abstract this so that it could be ported to other projects easily, but I didn't do much in the way of error proofing the script.