### PR TITLE
Extract csv parsing job

### DIFF
--- a/app/jobs/parse_csv_import_job.rb
+++ b/app/jobs/parse_csv_import_job.rb
@@ -1,0 +1,17 @@
+require 'csv'
+require 'open-uri'
+
+class ParseCsvImportJob < ActiveJob::Base
+  def perform(import_id, uri)
+    import = Import.find_by id: import_id
+    return unless import
+
+    stringio = open(uri)
+    stringio.set_encoding Encoding::UTF_8
+    data = stringio.read
+
+    csv = CSV.parse(data, headers: true)
+    csv.each { |row| import.raw_inputs.create data: row.to_h }
+    RawInputTransformJob.perform_later(import.id)
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -12,24 +12,19 @@ task :import_csv, [:source_name, :uri] => :environment do |_, args|
     abort 'Source not found.' unless source
 
     begin
-      stringio = open(uri)
+      open(uri)
     rescue OpenURI::HTTPError
       abort 'URI could not be opened.'
     end
-
-    stringio.set_encoding Encoding::UTF_8
-    data = stringio.read
 
     import = source.imports.create(
       description: "importing file: #{uri}",
       transformer: CsvTransformer
     )
 
-    csv = CSV.parse(data, headers: true)
-    csv.each { |row| import.raw_inputs.create data: row.to_h }
-    RawInputTransformJob.perform_later(import.id)
+    ParseCsvImportJob.perform_later(import.id, uri)
 
-    puts "Records queued to be imported: #{csv.length}"
+    puts "Import ##{import.id} created."
   else
     puts 'allowed headers:', CsvTransformer.allowed_headers
   end

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -52,7 +52,7 @@ describe 'Import rake task', task: true do
     it 'imports that csv file using that Source' do
       source = Fabricate :source, name: 'Example'
       stdout, status = Open3.capture2 command
-      expect(stdout).to eq "Records queued to be imported: 1\n"
+      expect(stdout).to eq "Import ##{source.imports.first.id} created.\n"
       expect(status.exitstatus).to eq 0
       expect(source.imports.count).to eq 1
       import = source.imports.first
@@ -73,7 +73,7 @@ describe 'Import rake task', task: true do
     it 'imports whatever information the file has for us' do
       source = Fabricate :source, name: 'Example'
       stdout, status = Open3.capture2 command
-      expect(stdout).to eq "Records queued to be imported: 1\n"
+      expect(stdout).to eq "Import ##{source.imports.first.id} created.\n"
       expect(status.exitstatus).to eq 0
       expect(source.imports.count).to eq 1
       import = source.imports.first


### PR DESCRIPTION
Rather than doing the parsing while the user waits for the rake task to finish, use a worker. This way the rake task can return almost immediately and the work of creating the `RawInput` records can happen in the background.

Note: this is another messy diff at the moment because I did this work on top of the other two open PRs. Would be happy to rebase when the time comes!!