### PR TITLE
Use a safer version of send when possible

### DIFF
--- a/app/models/raw_input_changes.rb
+++ b/app/models/raw_input_changes.rb
@@ -56,7 +56,7 @@ class RawInputChanges
     @relations_to_build.each do |relation|
       next unless @attrs[relation]
       method = relation.to_s.pluralize
-      object = @organization.send(method).build @attrs[relation]
+      object = @organization.public_send(method).build @attrs[relation]
       @relations[relation] = object
     end
   end


### PR DESCRIPTION
As @yuki24 pointed out, no reason not to use the `public_send` method instead.