### PR TITLE
Dynamic import show page

### DIFF
--- a/app/channels/import_channel.rb
+++ b/app/channels/import_channel.rb
@@ -1,0 +1,5 @@
+class ImportChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "import_#{@params[:import_id]}"
+  end
+end

--- a/app/jobs/raw_input_transform_job.rb
+++ b/app/jobs/raw_input_transform_job.rb
@@ -6,6 +6,8 @@ class RawInputTransformJob < ActiveJob::Base
     return unless raw_input
 
     RawInputChanges.apply raw_input
+    import_result = ImportResult.new(import)
+    ActionCable.server.broadcast "import_#{import_id}", import_result
     self.class.perform_later(import_id)
   end
 end

--- a/app/models/import_result.rb
+++ b/app/models/import_result.rb
@@ -30,4 +30,14 @@ class ImportResult
   def error_count
     raw_inputs.where(state: RawInput::ERROR).count
   end
+
+  def as_json(_)
+    {
+      status: status,
+      total_count: total_count,
+      created_count: created_count,
+      updated_count: updated_count,
+      error_count: error_count
+    }
+  end
 end

--- a/app/views/imports/show.html.haml
+++ b/app/views/imports/show.html.haml
@@ -16,9 +16,6 @@
 %table.table
   %tbody
     %tr
-      %td Raw Inputs
-      %td.total_count= import_result.total_count
-    %tr
       %td Created
       %td.created_count= import_result.created_count
     %tr
@@ -27,3 +24,6 @@
     %tr
       %td Errors
       %td.error_count= import_result.error_count
+    %tr
+      %td Total Raw Inputs
+      %td.total_count= import_result.total_count

--- a/app/views/imports/show.html.haml
+++ b/app/views/imports/show.html.haml
@@ -1,4 +1,15 @@
-%h1 #{import_result.name} (#{import_result.status})
+:coffee
+  App.cable.subscriptions.create { channel: 'ImportChannel', import_id: '#{import_result.import.id}' },
+    received: (data) ->
+      $('.status').text data.status
+      $('.total_count').text data.total_count
+      $('.created_count').text data.created_count
+      $('.updated_count').text data.updated_count
+      $('.error_count').text data.error_count
+
+%h1
+  #{import_result.name} -
+  %span.status= import_result.status
 
 %p= import_result.description
 
@@ -6,13 +17,13 @@
   %tbody
     %tr
       %td Raw Inputs
-      %td= import_result.total_count
+      %td.total_count= import_result.total_count
     %tr
       %td Created
-      %td= import_result.created_count
+      %td.created_count= import_result.created_count
     %tr
       %td Updated
-      %td= import_result.updated_count
+      %td.updated_count= import_result.updated_count
     %tr
       %td Errors
-      %td= import_result.error_count
+      %td.error_count= import_result.error_count

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: async

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   # see config/initializers/sidekiq.rb for security details
   mount Sidekiq::Web, at: '/sidekiq'
 
+  mount ActionCable.server => :cable
+
   resources :imports, only: [:new, :create, :show, :index]
   resources :tags, only: :index
 end

--- a/spec/features/csv_import_spec.rb
+++ b/spec/features/csv_import_spec.rb
@@ -22,7 +22,7 @@ feature 'CSV Import' do
     expect(page).to have_text import.description
 
     actual_counts = page.all('td + td').map(&:text)
-    expected_counts = %w(1 1 0 0)
+    expected_counts = %w(1 0 0 1)
     expect(actual_counts).to eq expected_counts
   end
 end

--- a/spec/features/csv_import_spec.rb
+++ b/spec/features/csv_import_spec.rb
@@ -18,7 +18,7 @@ feature 'CSV Import' do
 
     expect(source.imports.count).to eq 1
     import = source.imports.first
-    expect(page).to have_text "Factual import ##{import.id} (finished)"
+    expect(page).to have_text "Factual import ##{import.id} - finished"
     expect(page).to have_text import.description
 
     actual_counts = page.all('td + td').map(&:text)


### PR DESCRIPTION
This PR adds ActionCable to the app and uses it to update the counts on an Import show page. It's actually pretty fun to see the numbers zoom along as workers process the import! 😄 