### PR TITLE
Add annotate gem to annotate db schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
   gem 'dotenv-rails'
   gem 'listen'
   gem 'rails-erd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,17 +41,20 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    annotate (2.7.1)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 12.0)
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.7.7.1)
       execjs
-    aws-sdk (2.8.8)
-      aws-sdk-resources (= 2.8.8)
-    aws-sdk-core (2.8.8)
+    aws-sdk (2.8.11)
+      aws-sdk-resources (= 2.8.11)
+    aws-sdk-core (2.8.11)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.8)
-      aws-sdk-core (= 2.8.8)
+    aws-sdk-resources (2.8.11)
+      aws-sdk-core (= 2.8.11)
     aws-sigv4 (1.0.0)
     bootstrap (4.0.0.alpha6)
       autoprefixer-rails (>= 6.0.3)
@@ -102,7 +105,7 @@ GEM
       activesupport (>= 3.0.0, < 5.2)
       multi_json (~> 1.2)
     jmespath (1.3.1)
-    jquery-rails (4.2.2)
+    jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -139,8 +142,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-rails (0.3.5)
-      pry (>= 0.9.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
@@ -178,7 +181,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.1)
-    rake (12.0.0)
+    rake (11.3.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -201,7 +204,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.47.1)
+    rubocop (0.48.0)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -239,9 +242,9 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    uglifier (3.1.9)
+    uglifier (3.1.10)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.3)
     web-console (3.4.0)
@@ -259,6 +262,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   aws-sdk
   bootstrap (~> 4.0.0.alpha6)
   capybara
@@ -296,4 +300,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,5 @@ if %w(development test).include? Rails.env
   require 'rubocop/rake_task'
   desc 'Run RuboCop'
   RuboCop::RakeTask.new(:rubocop)
-  task default: [:rubocop, :spec]
+  task default: %i(rubocop spec)
 end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -18,7 +18,7 @@ class ImportsController < ApplicationController
 
   def import_params
     default = { transformer: CsvTransformer }
-    permitted = [:source_id, :description]
+    permitted = %i(source_id description)
     params.require(:import).permit(permitted).merge(default)
   end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,7 +1,18 @@
+# == Schema Information
+#
+# Table name: emails
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class Email < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
   validates_format_of :content, with: /@/
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
   include Rankable
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: imports
+#
+#  id          :integer          not null, primary key
+#  source_id   :integer
+#  description :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  transformer :string
+#
+
 class Import < ApplicationRecord
   belongs_to :source
   has_many :raw_inputs

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,7 +1,20 @@
+# == Schema Information
+#
+# Table name: locations
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  latitude        :float
+#  longitude       :float
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  content         :string
+#
+
 class Location < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
   include Rankable
 
   def geocoded?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Organization < ApplicationRecord
   has_many :emails
   has_many :locations
@@ -7,5 +16,5 @@ class Organization < ApplicationRecord
   has_many :tags, through: :organization_tags
   has_many :websites
 
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
 end

--- a/app/models/organization_name.rb
+++ b/app/models/organization_name.rb
@@ -1,9 +1,20 @@
+# == Schema Information
+#
+# Table name: organization_names
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  content         :string
+#
+
 class OrganizationName < ApplicationRecord
   belongs_to :organization
 
   validates :content, presence: true
   validates_uniqueness_of :content, scope: :organization
 
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
   include Rankable
 end

--- a/app/models/organization_tag.rb
+++ b/app/models/organization_tag.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: organization_tags
+#
+#  id              :integer          not null, primary key
+#  tag_id          :integer
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class OrganizationTag < ApplicationRecord
   class TagNotFound < StandardError; end
 
@@ -5,7 +16,7 @@ class OrganizationTag < ApplicationRecord
   belongs_to :tag
   validates_uniqueness_of :tag, scope: :organization
 
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
 
   def self.apply(tag_names, organization)
     Array(tag_names).each do |tag_name|

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,6 +1,17 @@
+# == Schema Information
+#
+# Table name: phone_numbers
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class PhoneNumber < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
   include Rankable
 end

--- a/app/models/raw_input.rb
+++ b/app/models/raw_input.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: raw_inputs
+#
+#  id            :integer          not null, primary key
+#  import_id     :integer
+#  output_id     :integer
+#  output_type   :string
+#  data          :json
+#  state         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  exception     :string
+#  error_details :json
+#
+
 class RawInput < ApplicationRecord
   belongs_to :import
 

--- a/app/models/raw_input_changes.rb
+++ b/app/models/raw_input_changes.rb
@@ -10,7 +10,7 @@ class RawInputChanges
     @attrs = raw_input.transform
     @organization = nil
     @relations = {}
-    @relations_to_build = [:email, :location, :organization_name, :phone_number]
+    @relations_to_build = %i(email location organization_name phone_number)
     @error_details = {}
   end
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: sources
+#
+#  id                     :integer          not null, primary key
+#  name                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  email_rank             :integer
+#  location_rank          :integer
+#  organization_name_rank :integer
+#  phone_number_rank      :integer
+#  website_rank           :integer
+#
+
 class Source < ApplicationRecord
   class UnknownRankable < StandardError; end
   has_many :imports

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Tag < ApplicationRecord
   has_many :organization_tags
   has_many :organizations, through: :organization_tags

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,8 +1,19 @@
+# == Schema Information
+#
+# Table name: websites
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class Website < ApplicationRecord
   belongs_to :organization
   validates :organization, presence: true
   validates :content, presence: true, uniqueness: true
   validates_format_of :content, with: /\./
-  has_paper_trail ignore: [:created_at, :updated_at]
+  has_paper_trail ignore: %i(created_at updated_at)
   include Rankable
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => :cable
 
-  resources :imports, only: [:new, :create, :show, :index]
+  resources :imports, only: %i(new create show index)
   resources :tags, only: :index
 end

--- a/db/migrate/20170210222250_create_versions.rb
+++ b/db/migrate/20170210222250_create_versions.rb
@@ -10,6 +10,6 @@ class CreateVersions < ActiveRecord::Migration
       t.text     :object
       t.datetime :created_at
     end
-    add_index :versions, [:item_type, :item_id]
+    add_index :versions, %i(item_type item_id)
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,7 +2,7 @@ require 'csv'
 require 'open-uri'
 
 desc 'Import csv file (run without args for allowed headers)'
-task :import_csv, [:source_name, :uri] => :environment do |_, args|
+task :import_csv, %i(source_name uri) => :environment do |_, args|
   if args.any?
     source_name = args[:source_name]
     uri = args[:uri]

--- a/spec/fabricators/email_fabricator.rb
+++ b/spec/fabricators/email_fabricator.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: emails
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 Fabricator :email do
   content { sequence(:email) { |i| "user#{i}@example.com" } }
 end

--- a/spec/fabricators/import_fabricator.rb
+++ b/spec/fabricators/import_fabricator.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: imports
+#
+#  id          :integer          not null, primary key
+#  source_id   :integer
+#  description :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  transformer :string
+#
+
 Fabricator :import do
   source { Fabricate :source }
 end

--- a/spec/fabricators/location_fabricator.rb
+++ b/spec/fabricators/location_fabricator.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: locations
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  latitude        :float
+#  longitude       :float
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  content         :string
+#
+
 Fabricator :location do
   content '123 Main Street, New York, NY 10001'
   latitude '10'

--- a/spec/fabricators/organization_fabricator.rb
+++ b/spec/fabricators/organization_fabricator.rb
@@ -1,2 +1,11 @@
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 Fabricator :organization do
 end

--- a/spec/fabricators/organization_name_fabricator.rb
+++ b/spec/fabricators/organization_name_fabricator.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: organization_names
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  content         :string
+#
+
 Fabricator :organization_name do
   content 'Gallery A'
 end

--- a/spec/fabricators/organization_tag_fabricator.rb
+++ b/spec/fabricators/organization_tag_fabricator.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: organization_tags
+#
+#  id              :integer          not null, primary key
+#  tag_id          :integer
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 Fabricator :organization_tag do
   tag { Fabricate :tag }
 end

--- a/spec/fabricators/phone_number_fabricator.rb
+++ b/spec/fabricators/phone_number_fabricator.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: phone_numbers
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 Fabricator :phone_number do
   content '1-800-555-7777'
 end

--- a/spec/fabricators/raw_input_fabricator.rb
+++ b/spec/fabricators/raw_input_fabricator.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: raw_inputs
+#
+#  id            :integer          not null, primary key
+#  import_id     :integer
+#  output_id     :integer
+#  output_type   :string
+#  data          :json
+#  state         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  exception     :string
+#  error_details :json
+#
+
 Fabricator :raw_input do
   import
 end

--- a/spec/fabricators/source_fabricator.rb
+++ b/spec/fabricators/source_fabricator.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: sources
+#
+#  id                     :integer          not null, primary key
+#  name                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  email_rank             :integer
+#  location_rank          :integer
+#  organization_name_rank :integer
+#  phone_number_rank      :integer
+#  website_rank           :integer
+#
+
 Fabricator :source do
   name { Fabricate.sequence(:name) { |i| "Source ##{i}" } }
   email_rank { Fabricate.sequence(:email_rank) }

--- a/spec/fabricators/tag_fabricator.rb
+++ b/spec/fabricators/tag_fabricator.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 Fabricator :tag do
   name { Fabricate.sequence(:tag_name) { |i| "tag ##{i}" } }
 end

--- a/spec/fabricators/website_fabricator.rb
+++ b/spec/fabricators/website_fabricator.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: websites
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  content         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 Fabricator :website do
   content { Fabricate.sequence(:website) { |i| "https://example#{i}.com" } }
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 describe Organization do

--- a/spec/models/organization_tag_spec.rb
+++ b/spec/models/organization_tag_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: organization_tags
+#
+#  id              :integer          not null, primary key
+#  tag_id          :integer
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 require 'rails_helper'
 
 describe OrganizationTag do


### PR DESCRIPTION
Adding one of my favorite gems, [annotate](https://github.com/ctran/annotate_models), to annotate db schema in various places, e.g. models and fabricators, and making them a bit self-explanatory. By default, annotate will be automatically run whenever we run `rake db:migrate` (only in development mode).

Also, updating some gems and fixing Rubocop warnings. 