### PR TITLE
Only create organizations when website is provided

### DIFF
--- a/app/models/raw_input_changes.rb
+++ b/app/models/raw_input_changes.rb
@@ -1,5 +1,6 @@
 class RawInputChanges
   class InvalidData < StandardError; end
+  class NoWebsiteBuilt < StandardError; end
 
   def self.apply(raw_input)
     new(raw_input).apply
@@ -59,6 +60,13 @@ class RawInputChanges
       object = @organization.public_send(method).build @attrs[relation]
       @relations[relation] = object
     end
+
+    ensure_website
+  end
+
+  def ensure_website
+    missing_website = @relations_to_build.include?(:website) && @organization.websites.none? # rubocop:disable Metrics/LineLength
+    raise NoWebsiteBuilt if missing_website
   end
 
   def apply_tags


### PR DESCRIPTION
I decided to add an exception for this case - that felt the most appropriate. I also opted to leave the `error_details` nil because I want to reserve that field for actual ActiveRecord validation errors. This might mean that an Importer could have to decipher exceptions, but maybe that's ok?

I sorta envision a list of exceptions and some explanation on the wiki so that we can help them out that way. Open to thoughts here!

closes #99