### PR TITLE
Add Source rankings table to list page

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -2,6 +2,16 @@ class SourcesController < ApplicationController
   expose(:sources) { Source.order(:name) }
   expose(:source)
 
+  expose(:ordered_sources) do
+    {
+      email_rank: Source.order(:email_rank),
+      location_rank: Source.order(:location_rank),
+      organization_name_rank: Source.order(:organization_name_rank),
+      phone_number_rank: Source.order(:phone_number_rank),
+      website_rank: Source.order(:website_rank)
+    }
+  end
+
   def create
     SourceResolver.resolve(source)
 

--- a/app/views/sources/index.html.haml
+++ b/app/views/sources/index.html.haml
@@ -5,3 +5,15 @@
 %ul
   - for source in sources
     %li= source.name
+
+%table.table
+  %thead
+    %tr
+      - for type in ordered_sources.keys
+        %th= type.to_s.humanize
+  %tbody
+    - (0...Source.count).to_a.each do |position|
+      %tr
+        - for type in ordered_sources.keys
+          - source = ordered_sources[type][position]
+          %td #{source.rank_for(type)}. #{source.name}

--- a/spec/fabricators/source_fabricator.rb
+++ b/spec/fabricators/source_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator :source do
-  name { Fabricate.sequence(:name) { |i| "Source ##{i}" } }
+  name { Fabricate.sequence(:name, 1) { |i| "Source ##{i}" } }
   email_rank { Fabricate.sequence(:email_rank, 1) }
   location_rank { Fabricate.sequence(:location_rank, 1) }
   organization_name_rank { Fabricate.sequence(:organization_name_rank, 1) }

--- a/spec/features/list_sources_spec.rb
+++ b/spec/features/list_sources_spec.rb
@@ -2,8 +2,70 @@ require 'rails_helper'
 
 feature 'List Sources' do
   scenario 'Importer views list of sources' do
-    sources = Fabricate.times 3, :source
+    Fabricate(
+      :source,
+      name: 'Source 1',
+      email_rank: 1,
+      location_rank: 2,
+      organization_name_rank: 1,
+      phone_number_rank: 1,
+      website_rank: 3
+    )
+
+    Fabricate(
+      :source,
+      name: 'Source 2',
+      email_rank: 3,
+      location_rank: 1,
+      organization_name_rank: 2,
+      phone_number_rank: 2,
+      website_rank: 1
+    )
+
+    Fabricate(
+      :source,
+      name: 'Source 3',
+      email_rank: 2,
+      location_rank: 3,
+      organization_name_rank: 3,
+      phone_number_rank: 3,
+      website_rank: 2
+    )
+
     visit '/sources'
-    sources.each { |source| expect(page).to have_text source.name }
+
+    Source.all.each { |source| expect(page).to have_text source.name }
+
+    (first_row, second_row, third_row) = page.all('tbody tr').to_a
+
+    expect(first_row.all('td').map(&:text)).to eq(
+      [
+        '1. Source 1',
+        '1. Source 2',
+        '1. Source 1',
+        '1. Source 1',
+        '1. Source 2'
+      ]
+    )
+
+    expect(second_row.all('td').map(&:text)).to eq(
+      [
+        '2. Source 3',
+        '2. Source 1',
+        '2. Source 2',
+        '2. Source 2',
+        '2. Source 3'
+      ]
+    )
+
+    expect(third_row.all('td').map(&:text)).to eq(
+      [
+        '3. Source 2',
+        '3. Source 3',
+        '3. Source 3',
+        '3. Source 3',
+        '3. Source 1'
+      ]
+    )
   end
 end


### PR DESCRIPTION
The idea here is that when you want to see how the ranks of sources are going to resolve, it's helpful to have this in a table.

![screen shot 2017-03-31 at 8 44 03 am](https://cloud.githubusercontent.com/assets/79799/24552988/3cd13da4-15ee-11e7-97a6-ec56f399bd34.png)

closes #133