### PR TITLE
Only sync when there is something to do

### DIFF
--- a/app/jobs/data_warehouse_sync_job.rb
+++ b/app/jobs/data_warehouse_sync_job.rb
@@ -1,5 +1,7 @@
 class DataWarehouseSyncJob < ApplicationJob
   def perform
+    return if nothing_to_sync?
+
     SlackBot.post('sync starting')
     update_finished_imports
 
@@ -11,6 +13,10 @@ class DataWarehouseSyncJob < ApplicationJob
   end
 
   private
+
+  def nothing_to_sync?
+    Import.where(state: ImportMicroMachine::FINISHED).empty?
+  end
 
   def update_finished_imports
     Import.where(state: ImportMicroMachine::FINISHED).each(&:sync)

--- a/spec/jobs/data_warehouse_sync_job_spec.rb
+++ b/spec/jobs/data_warehouse_sync_job_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe DataWarehouseSyncJob do
+  context 'with nothing to sync' do
+    it 'does nothing' do
+      expect(SlackBot).to_not receive(:post)
+      expect(DataWarehouseReset).to_not receive(:run)
+      DataWarehouseSyncJob.new.perform
+    end
+  end
+
   context 'with a successful reset' do
     it 'reverts Imports and posts errors to Slack' do
       import = Fabricate :import, state: ImportMicroMachine::FINISHED


### PR DESCRIPTION
Prior to this commit we'd be going through all the motions of syncing with Redshift even if there was nothing to do! Good catch @gnilekaw.

Note that while I considered reducing the duplication between `nothing_to_sync?` and `update_finished_imports`, I think it's fine. Check this out:

```ruby
> Import.where(state: ImportMicroMachine::FINISHED).any?
   (0.3ms)  SELECT COUNT(*) FROM "imports" WHERE "imports"."state" = $1  [["state", "finished"]]
=> false
```

That count statement is going to be really fast and if you extracted the `Import.where(state: ImportMicroMachine::FINISHED)` part, then you'd lose ActiveRecord's ability to optimize.