### PR TITLE
Misc UI tweaks

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,5 +1,4 @@
 class ImportsController < ApplicationController
-  # expose(:imports) { Import.order('created_at desc') }
   expose(:import_results) do
     Import.order('created_at desc').map(&ImportResult.method(:new))
   end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -4,6 +4,7 @@ class ImportsController < ApplicationController
   end
   expose(:import)
   expose(:import_result) { ImportResult.new(import) }
+  expose(:imports) { Import.order(id: :desc) }
 
   def create
     if import.save

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,10 +1,11 @@
 class ImportsController < ApplicationController
+  # expose(:imports) { Import.order('created_at desc') }
   expose(:import_results) do
     Import.order('created_at desc').map(&ImportResult.method(:new))
   end
+
   expose(:import)
   expose(:import_result) { ImportResult.new(import) }
-  expose(:imports) { Import.order(id: :desc) }
 
   def create
     if import.save

--- a/app/models/import_result.rb
+++ b/app/models/import_result.rb
@@ -2,9 +2,11 @@ class ImportResult
   attr_reader :import
 
   delegate(
+    :created_at,
     :description,
     :finished?,
     :id,
+    :uri,
     :raw_inputs,
     :source,
     :state,
@@ -16,7 +18,7 @@ class ImportResult
   end
 
   def name
-    "#{source.name} import ##{id}"
+    "#{source.name} import: #{id}"
   end
 
   def total_count

--- a/app/views/imports/index.html.haml
+++ b/app/views/imports/index.html.haml
@@ -2,6 +2,23 @@
 
 %h1 Imports
 
-%ul
-  - for import_result in import_results
-    %li= link_to import_result.name, import_path(import_result.import)
+%table.table
+  %thead
+    %tr
+      %th
+        &nbsp;
+      %th
+        Description
+      %th
+        State
+      %th
+        Created Date
+
+    %tbody
+      - for import in imports
+        %tr
+          %td= import.id
+          %td
+            %a{ href: import.uri }= import.description
+          %td= import.state.humanize
+          %td= import.created_at.strftime('%d %b %Y, %H:%M:%S')

--- a/app/views/imports/index.html.haml
+++ b/app/views/imports/index.html.haml
@@ -8,6 +8,7 @@
       %th Name
       %th Description
       %th State
+      %th Total Count
       %th Created Date
 
     %tbody
@@ -18,4 +19,5 @@
           %td
             %em= import_result.description
           %td= import_result.state.humanize
+          %td= import_result.total_count
           %td{ class: 'text-muted' }= import_result.created_at.strftime('%d %b %Y, %H:%M:%S')

--- a/app/views/imports/index.html.haml
+++ b/app/views/imports/index.html.haml
@@ -5,20 +5,17 @@
 %table.table
   %thead
     %tr
-      %th
-        &nbsp;
-      %th
-        Description
-      %th
-        State
-      %th
-        Created Date
+      %th Name
+      %th Description
+      %th State
+      %th Created Date
 
     %tbody
-      - for import in imports
+      - for import_result in import_results
         %tr
-          %td= import.id
           %td
-            %a{ href: import.uri }= import.description
-          %td= import.state.humanize
-          %td= import.created_at.strftime('%d %b %Y, %H:%M:%S')
+            %a{ href: import_result.uri }= import_result.name
+          %td
+            %em= import_result.description
+          %td= import_result.state.humanize
+          %td{ class: 'text-muted' }= import_result.created_at.strftime('%d %b %Y, %H:%M:%S')

--- a/app/views/imports/show.html.haml
+++ b/app/views/imports/show.html.haml
@@ -22,6 +22,9 @@
 
 %p= import_result.description
 
+%p
+  %a{ href: import.uri }= import.uri
+
 %table.table
   %tbody
     %tr

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,11 +7,11 @@
     = javascript_include_tag 'application'
   %body
     .container
-      %header
-        %h1 Bearden
-
-        %nav
-          %ul.nav.nav-pills
+      %nav{ class: %w(navbar navbar-toggleable-md navbar-light bg-faded) }
+        %a{ class: 'navbar-brand' }
+          Bearden
+        %div{ class: %w(collapse navbar-collapse) }
+          %ul{ class: %w(navbar-nav mr-auto) }
             %li.nav-item= link_to 'Imports', imports_path, { class: nav_class(:imports) }
             %li.nav-item= link_to 'Sources', sources_path, { class: nav_class(:sources) }
             %li.nav-item= link_to 'Tags', tags_path, { class: nav_class(:tags) }

--- a/app/views/sources/index.html.haml
+++ b/app/views/sources/index.html.haml
@@ -2,18 +2,16 @@
 
 %h1 Sources
 
-%ul
-  - for source in sources
-    %li= source.name
-
 %table.table
   %thead
     %tr
+      %th &nbsp;
       - for type in ordered_sources.keys
         %th= type.to_s.humanize
   %tbody
-    - (0...Source.count).to_a.each do |position|
+    - (0...Source.count).to_a.each_with_index do |position, index|
       %tr
+        %td #{index + 1}
         - for type in ordered_sources.keys
           - source = ordered_sources[type][position]
-          %td #{source.rank_for(type)}. #{source.name}
+          %td #{source.name}

--- a/app/views/sources/index.html.haml
+++ b/app/views/sources/index.html.haml
@@ -9,9 +9,9 @@
       - for type in ordered_sources.keys
         %th= type.to_s.humanize
   %tbody
-    - (0...Source.count).to_a.each_with_index do |position, index|
+    - (0...Source.count).each do |position|
       %tr
-        %td #{index + 1}
+        %td #{position + 1}
         - for type in ordered_sources.keys
           - source = ordered_sources[type][position]
           %td #{source.name}

--- a/spec/features/csv_import_spec.rb
+++ b/spec/features/csv_import_spec.rb
@@ -16,7 +16,7 @@ feature 'CSV Import' do
 
     expect(source.imports.count).to eq 1
     import = source.imports.first
-    expect(page).to have_text "Factual import ##{import.id} - finished"
+    expect(page).to have_text "Factual import: #{import.id} - finished"
     expect(page).to have_text import.description
 
     actual_counts = page.all('td + td').map(&:text)

--- a/spec/features/list_imports_spec.rb
+++ b/spec/features/list_imports_spec.rb
@@ -8,7 +8,7 @@ describe 'List Imports' do
     visit '/imports'
 
     imports.each do |import|
-      expect(page).to have_text "Clearbit import ##{import.id}"
+      expect(page).to have_text "Clearbit import: #{import.id}"
     end
   end
 end

--- a/spec/features/list_sources_spec.rb
+++ b/spec/features/list_sources_spec.rb
@@ -40,31 +40,34 @@ feature 'List Sources' do
 
     expect(first_row.all('td').map(&:text)).to eq(
       [
-        '1. Source 1',
-        '1. Source 2',
-        '1. Source 1',
-        '1. Source 1',
-        '1. Source 2'
+        '1',
+        'Source 1',
+        'Source 2',
+        'Source 1',
+        'Source 1',
+        'Source 2'
       ]
     )
 
     expect(second_row.all('td').map(&:text)).to eq(
       [
-        '2. Source 3',
-        '2. Source 1',
-        '2. Source 2',
-        '2. Source 2',
-        '2. Source 3'
+        '2',
+        'Source 3',
+        'Source 1',
+        'Source 2',
+        'Source 2',
+        'Source 3'
       ]
     )
 
     expect(third_row.all('td').map(&:text)).to eq(
       [
-        '3. Source 2',
-        '3. Source 3',
-        '3. Source 3',
-        '3. Source 3',
-        '3. Source 1'
+        '3',
+        'Source 2',
+        'Source 3',
+        'Source 3',
+        'Source 3',
+        'Source 1'
       ]
     )
   end

--- a/spec/models/import_result_spec.rb
+++ b/spec/models/import_result_spec.rb
@@ -5,7 +5,7 @@ describe ImportResult do
     it 'returns the name' do
       import = Fabricate :import
       import_result = ImportResult.new(import)
-      expected_name = "#{import.source.name} import ##{import.id}"
+      expected_name = "#{import.source.name} import: #{import.id}"
       expect(import_result.name).to eq expected_name
     end
   end


### PR DESCRIPTION
Add a table to display imports on the imports page more clearly.

Closes https://github.com/artsy/bearden/issues/136
Closes https://github.com/artsy/bearden/issues/134

## Imports: Before

<img width="999" alt="screen shot 2017-04-03 at 11 21 43 am" src="https://cloud.githubusercontent.com/assets/7292475/24616666/c7c31bd0-185f-11e7-99b5-71665c7f44b7.png">

## Imports: After

<img width="995" alt="screen shot 2017-04-03 at 11 14 47 am" src="https://cloud.githubusercontent.com/assets/7292475/24616602/9cac793c-185f-11e7-9ac4-19a1eb5730a3.png">

## Sources: Before

<img width="1011" alt="screen shot 2017-04-03 at 11 21 51 am" src="https://cloud.githubusercontent.com/assets/7292475/24616693/dfa8dfaa-185f-11e7-9186-9421d0ce636f.png">


## Sources: After

<img width="1003" alt="screen shot 2017-04-03 at 11 20 30 am" src="https://cloud.githubusercontent.com/assets/7292475/24616601/9ca239c2-185f-11e7-987a-52272fff9dce.png">

