### PR TITLE
Add list page for viewing recent Syncs

### DIFF
--- a/app/controllers/syncs_controller.rb
+++ b/app/controllers/syncs_controller.rb
@@ -1,0 +1,5 @@
+class SyncsController < ApplicationController
+  expose(:recent_sync_results) do
+    Sync.order(created_at: :desc).limit(20).map(&SyncResult.method(:new))
+  end
+end

--- a/app/models/sync_result.rb
+++ b/app/models/sync_result.rb
@@ -1,0 +1,28 @@
+class SyncResult
+  attr_reader :sync
+
+  delegate(
+    :created_at,
+    :id,
+    :state,
+    :total_parts,
+    :updated_at,
+    :uploaded_parts,
+    to: :sync
+  )
+
+  include ActionView::Helpers::DateHelper
+
+  def initialize(sync)
+    @sync = sync
+  end
+
+  def duration
+    distance_of_time_in_words updated_at, created_at
+  end
+
+  def parts
+    return 'n/a' if state == SyncMicroMachine::SKIPPED
+    "#{uploaded_parts}/#{total_parts}"
+  end
+end

--- a/app/views/syncs/index.html.haml
+++ b/app/views/syncs/index.html.haml
@@ -1,0 +1,18 @@
+%h1 Syncs
+
+%table.table
+  %thead
+    %tr
+      %th Number
+      %th State
+      %th Parts
+      %th Duration
+      %th Created At
+  %tbody
+    - for sync_result in recent_sync_results
+      %tr
+        %td= sync_result.id
+        %td= sync_result.state
+        %td= sync_result.parts
+        %td= sync_result.duration
+        %td= sync_result.created_at.to_s(:list_page)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
 
   resources :imports, only: %i(create index new show)
   resources :sources, only: %i(create index new)
+  resources :syncs, only: :index
   resources :tags, only: :index
 end

--- a/spec/features/list_syncs_spec.rb
+++ b/spec/features/list_syncs_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe 'List Syncs' do
+  scenario 'Importer views list of syncs' do
+    skipped_sync = Fabricate(
+      :sync,
+      state: SyncMicroMachine::SKIPPED,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+
+    finished_sync = Fabricate(
+      :sync,
+      state: SyncMicroMachine::FINISHED,
+      total_parts: 2,
+      uploaded_parts: 2,
+      created_at: 20.minutes.ago,
+      updated_at: 5.minutes.ago
+    )
+
+    exporting_sync = Fabricate(
+      :sync,
+      state: SyncMicroMachine::EXPORTING,
+      total_parts: 2,
+      uploaded_parts: 1,
+      created_at: 5.minutes.ago,
+      updated_at: 2.minutes.ago
+    )
+
+    visit '/syncs'
+
+    (first_row, second_row, third_row) = page.all('tbody tr').to_a
+
+    expect(first_row.all('td').map(&:text)).to eq(
+      [
+        exporting_sync.id.to_s,
+        SyncMicroMachine::EXPORTING,
+        '1/2',
+        '3 minutes',
+        exporting_sync.created_at.to_s(:list_page)
+      ]
+    )
+
+    expect(second_row.all('td').map(&:text)).to eq(
+      [
+        skipped_sync.id.to_s,
+        SyncMicroMachine::SKIPPED,
+        'n/a',
+        'less than a minute',
+        skipped_sync.created_at.to_s(:list_page)
+      ]
+    )
+
+    expect(third_row.all('td').map(&:text)).to eq(
+      [
+        finished_sync.id.to_s,
+        SyncMicroMachine::FINISHED,
+        '2/2',
+        '15 minutes',
+        finished_sync.created_at.to_s(:list_page)
+      ]
+    )
+  end
+end


### PR DESCRIPTION
While working on Syncs, it was often annoying that I couldn't see at a glance what had recently happened, so I cooked up this list page. Most of the time it'll look like this:

![screen shot 2017-04-10 at 11 47 02 am](https://cloud.githubusercontent.com/assets/79799/24872588/8c291cda-1de3-11e7-910d-aab470c42014.png)

But when there are Syncs that have happened, it'll be a nice way to see them. I also had ideas about computing an average for how long finished syncs took, but didn't get to it - we'll see if it comes up again.