### PR TITLE
Remove uniqueness constraint from org name

### DIFF
--- a/app/models/organization_name.rb
+++ b/app/models/organization_name.rb
@@ -2,7 +2,6 @@ class OrganizationName < ApplicationRecord
   belongs_to :organization
 
   validates :content, presence: true
-  validates_uniqueness_of :content, scope: :organization
 
   has_paper_trail ignore: %i(created_at updated_at)
   include Rankable


### PR DESCRIPTION
Rather than have this Rankable behave differently than the others, we've
decided that it should rely on Source rank resolution too.

closes #104