### PR TITLE
Handle tag errors on import

### DIFF
--- a/app/models/import_errors.rb
+++ b/app/models/import_errors.rb
@@ -43,9 +43,20 @@ class ImportErrors
   end
 
   def errors_from_details(details)
+    errors = rankeable_errors(details) + tag_errors(details)
+    errors.compact.join(', ')
+  end
+
+  def rankeable_errors(details)
     details.flat_map do |field, detail|
+      next if field == 'tags'
       errors = detail['content'].pluck('error')
       errors.flat_map { |error| [field, error].join(' ') }
-    end.join(', ')
+    end
+  end
+
+  def tag_errors(details)
+    return [] unless details.key?('tags')
+    [details['tags'].split(':').first]
   end
 end

--- a/spec/models/import_errors_spec.rb
+++ b/spec/models/import_errors_spec.rb
@@ -10,7 +10,7 @@ describe ImportErrors do
       end
     end
 
-    context 'with some errors' do
+    context 'with rankable errors' do
       it 'exports those errors to S3 in CSV format' do
         import = Fabricate :import
 
@@ -43,12 +43,51 @@ describe ImportErrors do
 
         error_messages = 'email invalid, website invalid, website taken'
 
-        rows = [
-          [email, website, exception, error_messages]
-        ]
+        rows = [[email, website, exception, error_messages]]
 
         filename = "errors/#{import.id}.csv"
         headers = %w(email website exception error_details)
+
+        options = {
+          rows: rows,
+          filename: filename,
+          headers: headers,
+          acl: S3CsvExport::PUBLIC
+        }
+
+        expect(S3CsvExport).to receive(:create).with(options)
+        ImportErrors.export(import)
+      end
+    end
+
+    context 'with tag errors' do
+      it 'exports those errors to S3 in CSV format' do
+        import = Fabricate :import
+        exception = 'RawInputChanges::InvalidData'
+
+        tag_names = %w(design)
+
+        data = {
+          tag_names: tag_names
+        }
+
+        error_details = {
+          tags: "all tags could not be applied: #{tag_names}"
+        }
+
+        Fabricate(
+          :raw_input,
+          data: data,
+          error_details: error_details,
+          exception: exception,
+          import: import,
+          state: RawInput::ERROR
+        )
+
+        error_message = 'all tags could not be applied'
+        rows = [[tag_names, exception, error_message]]
+        filename = "errors/#{import.id}.csv"
+        headers = %w(tag_names exception error_details)
 
         options = {
           rows: rows,


### PR DESCRIPTION
Prior to this commit we had implemented passing tag errors up the stack,
but didn't have any specs around it and sure enough, the implementation
wasn't flexible enough. This commit fixes our implementation and also
adds the missing spec.