### PR TITLE
Don't include deploy commits in deploy PR

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -4,7 +4,7 @@
 project=$(git remote show upstream | grep Fetch | cut -d ':' -f 3 | cut -d '.' -f 1)
 
 # show included PRs
-prs=$(git log upstream/release...upstream/master --merges --oneline | cut -d ' ' -f 5 | cut -d '#' -f 2)
+prs=$(git log upstream/release...upstream/master --merges --oneline --grep 'from artsy/master' --invert-grep | cut -d ' ' -f 5 | cut -d '#' -f 2)
 
 body="Included PRs:\n\n"
 for pr in $prs; do


### PR DESCRIPTION
Prior to this commit, the log statement would include the PRs on release
that were for previous deploys. My git-foo wasn't good enough to filter
them, so I just resorted to grep.