### PR TITLE
Resolve websites to improve matching logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,5 @@ group :test do
   gem 'capybara'
   gem 'database_cleaner'
   gem 'fabrication'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
     decent_exposure (3.0.2)
       activesupport (>= 4.0)
@@ -254,6 +256,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.7)
       tilt
+    hashdiff (0.3.2)
     hashie (3.5.5)
     i18n (0.8.1)
     inflecto (0.0.2)
@@ -393,6 +396,7 @@ GEM
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -444,6 +448,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -493,6 +501,7 @@ DEPENDENCIES
   spring-watcher-listen
   uglifier
   web-console
+  webmock
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/models/organization_builder.rb
+++ b/app/models/organization_builder.rb
@@ -1,0 +1,39 @@
+class OrganizationBuilder
+  class NoWebsiteBuilt < StandardError; end
+
+  attr_reader :organization
+
+  def initialize(input_website)
+    @input_website = input_website
+    @created = false
+  end
+
+  def find_or_create
+    return if organization_from(@input_website)
+
+    create_organization
+    raise NoWebsiteBuilt unless website_built?
+  end
+
+  def created?
+    @created
+  end
+
+  private
+
+  def organization_from(content)
+    website = Website.find_by content: content
+    @organization = website&.organization
+  end
+
+  def create_organization
+    @organization = Organization.create
+    @organization.websites.create content: @input_website
+
+    @created = true
+  end
+
+  def website_built?
+    @organization.reload.websites.any?
+  end
+end

--- a/app/models/organization_builder.rb
+++ b/app/models/organization_builder.rb
@@ -11,7 +11,15 @@ class OrganizationBuilder
   def find_or_create
     return if organization_from(@input_website)
 
-    create_organization
+    resolve_website
+    organization_from(resolved_url)
+
+    create_organization unless @organization
+
+    @resolver.results.each do |attrs|
+      @organization.websites.create attrs
+    end
+
     raise NoWebsiteBuilt unless website_built?
   end
 
@@ -26,10 +34,16 @@ class OrganizationBuilder
     @organization = website&.organization
   end
 
+  def resolved_url
+    @resolver.resolved_url
+  end
+
+  def resolve_website
+    @resolver = WebsiteResolver.resolve(@input_website)
+  end
+
   def create_organization
     @organization = Organization.create
-    @organization.websites.create content: @input_website
-
     @created = true
   end
 

--- a/app/models/website_resolver.rb
+++ b/app/models/website_resolver.rb
@@ -31,7 +31,7 @@ class WebsiteResolver
   end
 
   def protocol?
-    %r{http(s?)://}.match @url
+    @url.start_with? 'http://', 'https://'
   end
 
   def add_protocol
@@ -39,10 +39,10 @@ class WebsiteResolver
   end
 
   def connection
-    options = { callback: method(:callback) }
+    redirect_options = { callback: method(:callback) }
 
     @connection ||= Faraday.new do |faraday|
-      faraday.use FaradayMiddleware::FollowRedirects, options
+      faraday.use FaradayMiddleware::FollowRedirects, redirect_options
       faraday.adapter Faraday.default_adapter
     end
   end
@@ -51,8 +51,8 @@ class WebsiteResolver
     add_result(old)
   end
 
-  def add_result(env)
-    result = { status: env[:status], content: env[:url].to_s }
+  def add_result(faraday_env)
+    result = { status: faraday_env[:status], content: faraday_env[:url].to_s }
     @results << result
   end
 end

--- a/app/models/website_resolver.rb
+++ b/app/models/website_resolver.rb
@@ -1,0 +1,58 @@
+class WebsiteResolver
+  attr_reader :results
+
+  def self.resolve(url)
+    resolver = new(url)
+    resolver.resolve
+    resolver
+  end
+
+  def initialize(url)
+    @url = url
+    @results = []
+  end
+
+  def resolve
+    resolve_url if @url
+  end
+
+  def resolved_url
+    @results.last&.fetch :content
+  end
+
+  private
+
+  def resolve_url
+    add_protocol unless protocol?
+    response = connection.get(@url)
+    add_result(response.env)
+  rescue Faraday::Error
+    @results = []
+  end
+
+  def protocol?
+    %r{http(s?)://}.match @url
+  end
+
+  def add_protocol
+    @url = "http://#{@url}"
+  end
+
+  def connection
+    options = { callback: method(:callback) }
+
+    @connection ||= Faraday.new do |faraday|
+      faraday.use FaradayMiddleware::FollowRedirects, options
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+
+  def callback(old, _)
+    add_result(old)
+  end
+
+  def add_result(env)
+    result = { status: env[:status], content: env[:url].to_s }
+    @results << result
+  end
+end

--- a/db/migrate/20170417212810_add_status_to_websites.rb
+++ b/db/migrate/20170417212810_add_status_to_websites.rb
@@ -1,0 +1,5 @@
+class AddStatusToWebsites < ActiveRecord::Migration[5.0]
+  def change
+    add_column :websites, :status, :integer
+  end
+end

--- a/spec/features/csv_import_spec.rb
+++ b/spec/features/csv_import_spec.rb
@@ -4,6 +4,11 @@ feature 'CSV Import' do
   scenario 'Import one complete gallery' do
     csv_file = 'spec/fixtures/one_complete_gallery.csv'
 
+    website = 'http://example.com'
+    results = [{ status: 200, content: website }]
+    resolver = double(:resolver, results: results, resolved_url: website)
+    expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
+
     allow_any_instance_of(S3Uploader).to receive(:store!)
     allow_any_instance_of(Fog::Storage::AWS::GetObjectUrl)
       .to receive(:get_object_url).and_return(csv_file)

--- a/spec/models/organization_builder_spec.rb
+++ b/spec/models/organization_builder_spec.rb
@@ -18,9 +18,45 @@ describe OrganizationBuilder do
       end
     end
 
+    context 'with a matching website after resolution' do
+      it 'creates a website for the redirect and finds the organization' do
+        organization = Fabricate :organization
+        website = Fabricate(
+          :website,
+          organization: organization,
+          content: 'https://www.artsy.net/'
+        )
+
+        results = [
+          { status: 301, content: 'http://artsy.net' },
+          { status: 200, content: website.content }
+        ]
+
+        resolver = double(
+          :resolver,
+          resolved_url: website.content,
+          results: results
+        )
+        expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
+
+        builder = OrganizationBuilder.new('artsy.net')
+        builder.find_or_create
+
+        expect(Organization.count).to eq 1
+        organization = builder.organization
+        expect(organization.websites.count).to eq 2
+        expect(builder).to_not be_created
+      end
+    end
+
     context 'with a new website' do
       it 'creates and organization and website' do
-        builder = OrganizationBuilder.new('http://example.com')
+        website = 'http://example.com'
+        results = [{ status: 200, content: website }]
+        resolver = double(:resolver, results: results, resolved_url: website)
+        expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
+
+        builder = OrganizationBuilder.new(website)
         builder.find_or_create
 
         expect(Organization.count).to eq 1
@@ -32,6 +68,9 @@ describe OrganizationBuilder do
 
     context 'with an invalid website' do
       it 'raises an exception' do
+        resolver = double(:resolver, results: [], resolved_url: nil)
+        expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
+
         builder = OrganizationBuilder.new('example')
 
         expect do

--- a/spec/models/organization_builder_spec.rb
+++ b/spec/models/organization_builder_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe OrganizationBuilder do
+  describe 'building' do
+    context 'with a matching website' do
+      it 'finds the organization for that website and does not create one' do
+        organization = Fabricate :organization
+        website = Fabricate :website, organization: organization
+
+        builder = OrganizationBuilder.new(website.content)
+        builder.find_or_create
+
+        expect(builder.organization).to eq organization
+        expect(builder).to_not be_created
+
+        expect(Organization.count).to eq 1
+        expect(Website.count).to eq 1
+      end
+    end
+
+    context 'with a new website' do
+      it 'creates and organization and website' do
+        builder = OrganizationBuilder.new('http://example.com')
+        builder.find_or_create
+
+        expect(Organization.count).to eq 1
+        organization = builder.organization
+        expect(organization.websites.count).to eq 1
+        expect(builder).to be_created
+      end
+    end
+
+    context 'with an invalid website' do
+      it 'raises an exception' do
+        builder = OrganizationBuilder.new('example')
+
+        expect do
+          builder.find_or_create
+        end.to raise_error OrganizationBuilder::NoWebsiteBuilt
+      end
+    end
+  end
+end

--- a/spec/models/raw_input_changes_spec.rb
+++ b/spec/models/raw_input_changes_spec.rb
@@ -23,6 +23,12 @@ describe RawInputChanges do
             website: 'http://example.com'
           }
           raw_input = Fabricate :raw_input, import: import, data: data
+
+          website = 'http://example.com'
+          results = [{ status: 200, content: website }]
+          resolver = double(:resolver, results: results, resolved_url: website)
+          expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
+
           RawInputChanges.apply raw_input
 
           [
@@ -109,6 +115,10 @@ describe RawInputChanges do
             website: 'http://example.com'
           }
           raw_input = Fabricate :raw_input, import: import, data: data
+          website = 'http://example.com'
+          results = [{ status: 200, content: website }]
+          resolver = double(:resolver, results: results, resolved_url: website)
+          expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
           RawInputChanges.apply raw_input
 
           [
@@ -155,6 +165,10 @@ describe RawInputChanges do
           }
           raw_input = Fabricate :raw_input, import: import, data: data
 
+          website = 'http://example.com'
+          results = [{ status: 200, content: website }]
+          resolver = double(:resolver, results: results, resolved_url: website)
+          expect(WebsiteResolver).to receive(:resolve).and_return(resolver)
           RawInputChanges.apply raw_input
 
           [

--- a/spec/models/raw_input_changes_spec.rb
+++ b/spec/models/raw_input_changes_spec.rb
@@ -81,7 +81,8 @@ describe RawInputChanges do
           ].each do |klass|
             expect(klass.count).to eq 0
           end
-          expect(raw_input.exception).to eq 'RawInputChanges::NoWebsiteBuilt'
+          exception = 'OrganizationBuilder::NoWebsiteBuilt'
+          expect(raw_input.exception).to eq exception
           expect(raw_input.state).to eq RawInput::ERROR
 
           expect(PaperTrail.whodunnit).to eq 'Test User'
@@ -150,7 +151,7 @@ describe RawInputChanges do
             organization_name: 'Best Gallery',
             phone_number: '1-800-123-4567',
             tag_names: 'invalid',
-            website: 'examplecom'
+            website: 'example.com'
           }
           raw_input = Fabricate :raw_input, import: import, data: data
 
@@ -172,8 +173,7 @@ describe RawInputChanges do
             {
               'email' => { 'content' => [{ 'error' => 'invalid', 'value' => 'infoexample.com' }] }, # rubocop:disable Metrics/LineLength
               'location' => { 'content' => [{ 'error' => 'blank' }] },
-              'tags' => 'all tags could not be applied: invalid',
-              'website' => { 'content' => [{ 'error' => 'invalid', 'value' => 'examplecom' }] } # rubocop:disable Metrics/LineLength
+              'tags' => 'all tags could not be applied: invalid'
             }
           )
           expect(raw_input.state).to eq RawInput::ERROR

--- a/spec/models/website_resolver_spec.rb
+++ b/spec/models/website_resolver_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe WebsiteResolver do
+  context 'when url is nil' do
+    it 'returns en empty array' do
+      results = WebsiteResolver.resolve(nil).results
+      expect(results).to eq []
+    end
+  end
+
+  context 'when there is no protocol' do
+    it 'returns that url with the protocol added' do
+      stub_request(:get, 'http://www.example.com')
+      results = WebsiteResolver.resolve('www.example.com/').results
+      expect(results).to eq [
+        { status: 200, content: 'http://www.example.com/' }
+      ]
+    end
+  end
+
+  context 'with the https protocol' do
+    it 'does not alter protocol' do
+      secure_url = 'https://www.artsy.net/'
+      stub_request(:get, secure_url)
+      results = WebsiteResolver.resolve(secure_url).results
+      expect(results).to eq [
+        { status: 200, content: secure_url }
+      ]
+    end
+  end
+
+  context 'when the url redirects' do
+    it 'returns both urls' do
+      redirect_url = 'http://artsy.net'
+      resolved_url = 'https://www.artsy.net/'
+      headers = { 'Location' => resolved_url }
+      stub_request(:get, redirect_url)
+        .to_return(status: 301, headers: headers)
+      stub_request(:get, resolved_url)
+      resolver = WebsiteResolver.resolve(redirect_url)
+      results = resolver.results
+      expect(results).to eq [
+        { status: 301, content: redirect_url },
+        { status: 200, content: resolved_url }
+      ]
+
+      expect(resolver.resolved_url).to eq resolved_url
+    end
+  end
+
+  context 'when the url is a 404' do
+    it 'returns that url and status' do
+      unknown_url = 'https://www.artsy.net/unknown.html'
+      stub_request(:get, unknown_url).to_return(status: 404)
+      results = WebsiteResolver.resolve(unknown_url).results
+      expect(results).to eq [{ status: 404, content: unknown_url }]
+    end
+  end
+
+  context 'when the url cannot be resolved' do
+    it 'returns an empty array' do
+      message = 'Failed to open TCP connection'
+      exception = Faraday::ConnectionFailed.new(message)
+      connection = double(:connection)
+      allow(connection).to receive(:get).and_raise exception
+      allow(Faraday).to receive(:new).and_return(connection)
+      results = WebsiteResolver.resolve('something').results
+      expect(results).to eq []
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
This commit introduces the concept of resolving a website. We take what
comes from the RawInput and do a little normalization (adding protocol)
and then throw that at Faraday which we've configured to follow
redirects.

Note: we do not perform this resolution if there's a match to begin
with, so we're about as conservative with our network calls as we can
be.

Also note: we blow up the whole row if the website 404s.

closes #131