### PR TITLE
Remove unused load_error method and add more descriptive PG error

### DIFF
--- a/spec/models/data_warehouse_spec.rb
+++ b/spec/models/data_warehouse_spec.rb
@@ -4,13 +4,11 @@ describe DataWarehouse do
   describe '.reset' do
     context 'with a Postgres error' do
       it 'returns a result with those errors' do
-        result = DataWarehouse::Result.new
         connection = double(:connection)
         allow(connection).to receive(:exec).and_raise PG::Error
-
-        expect do
-          DataWarehouse.new(['s3://path/to.csv'], result, connection).reset
-        end.to raise_error PG::Error
+        allow(Redshift).to receive(:connect).and_yield connection
+        result = DataWarehouse.reset(nil)
+        expect(result.errors).to eq 'PG::Error: PG::Error'
       end
     end
 


### PR DESCRIPTION
The `load_errors` method was  useful during initial development when uploading data to Redshift was throwing cryptic errors. After living with it for a while though, we haven't encountered even one of these errors after uploading lots of data. _But_ we did get a fatal error when we changed the schema and did not update Redshift. This is way more likely to happen from time to time. So hopefully, this will catch that error and describe it in a helpful way.