### PR TITLE
Add Aptfile to install icu on Heroku

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+libicu52
+libicu-dev


### PR DESCRIPTION
Turns out we were getting failed builds on Circle because Heroku was failing to install charlock_holmes - a quick Google search found this:

https://github.com/brianmario/charlock_holmes/wiki/Installing-charlock-holmes-and-libicu-dev-on-heroku

And I should have know - in fact, I thought about this, but couldn't find an `icu` locally, so figured I was just wrong. Nope!

Anyway, the fix is simple - have Heroku install the lib for us using the apt buildpack.