### PR TITLE
Export field with array of input sources to Redshift

### DIFF
--- a/app/models/auditable.rb
+++ b/app/models/auditable.rb
@@ -1,0 +1,11 @@
+module Auditable
+  extend ActiveSupport::Concern
+
+  included do
+    has_paper_trail ignore: %i[created_at updated_at]
+  end
+
+  def sources
+    versions.map { |version| version.actor.source }
+  end
+end

--- a/app/models/auditable.rb
+++ b/app/models/auditable.rb
@@ -6,6 +6,6 @@ module Auditable
   end
 
   def sources
-    versions.map { |version| version.actor.source }
+    versions.map { |version| version.actor.import.source }
   end
 end

--- a/app/models/csv_converter.rb
+++ b/app/models/csv_converter.rb
@@ -13,6 +13,7 @@ class CsvConverter
       phone_number
       tag_names
       website
+      sources
     ]
   end
   # rubocop:enable Metrics/MethodLength
@@ -38,7 +39,8 @@ class CsvConverter
       @input[:organization_name],
       @input[:phone_number],
       @input[:tag_names],
-      @input[:website]
+      @input[:website],
+      @input[:sources]
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -2,6 +2,6 @@ class Email < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
   validates_format_of :content, with: /@/
-  has_paper_trail ignore: %i[created_at updated_at]
+  include Auditable
   include Rankable
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,8 +1,8 @@
 class Location < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
-  has_paper_trail ignore: %i[created_at updated_at]
   include Rankable
+  include Auditable
 
   def geocoded?
     latitude.present? && longitude.present?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,15 +10,16 @@ class Organization < ApplicationRecord
   include Auditable
 
   def contributing_sources
-    auditable_collections.map do |model_name|
-      sources = send(model_name).map(&:sources)
-      sources << self.sources
-    end.flatten.uniq
+    sources = self.sources
+    sources << auditable_relations.map do |model_name|
+      send(model_name).map(&:sources)
+    end
+    sources.flatten.uniq
   end
 
   private
 
-  def auditable_collections
+  def auditable_relations
     keys = self.class.reflections.keys
 
     relations = keys.each_with_object({}) do |key, obj|

--- a/app/models/organization_name.rb
+++ b/app/models/organization_name.rb
@@ -1,8 +1,6 @@
 class OrganizationName < ApplicationRecord
   belongs_to :organization
-
   validates :content, presence: true
-
-  has_paper_trail ignore: %i[created_at updated_at]
+  include Auditable
   include Rankable
 end

--- a/app/models/organization_resolver.rb
+++ b/app/models/organization_resolver.rb
@@ -49,23 +49,8 @@ class OrganizationResolver
     @organization&.tags || []
   end
 
-  def entities
-    [
-      @organization,
-      @email,
-      @location,
-      @organization_name,
-      @phone_number,
-      @website
-    ]
-  end
-
   def source_names
-    entities.reduce([]) do |memo, entity|
-      next entity if entity.nil?
-      name = entity.versions.last.actor.import.source.name
-      memo.include?(name) ? memo : memo << name
-    end
+    @organization.contributing_sources.map(&:source)
   end
 
   def tag_names

--- a/app/models/organization_resolver.rb
+++ b/app/models/organization_resolver.rb
@@ -39,13 +39,33 @@ class OrganizationResolver
       organization_name: @organization_name&.content,
       phone_number: @phone_number&.content,
       tag_names: tag_names,
-      website: @website&.content
+      website: @website&.content,
+      sources: source_names
     }.compact
   end
   # rubocop:enable Metrics/MethodLength
 
   def organization_tag_names
     @organization&.tags || []
+  end
+
+  def entities
+    [
+      @organization,
+      @email,
+      @location,
+      @organization_name,
+      @phone_number,
+      @website
+    ]
+  end
+
+  def source_names
+    entities.reduce([]) do |memo, entity|
+      next entity if entity.nil?
+      name = entity.versions.last.actor.import.source.name
+      memo.include?(name) ? memo : memo << name
+    end
   end
 
   def tag_names

--- a/app/models/organization_resolver.rb
+++ b/app/models/organization_resolver.rb
@@ -50,7 +50,7 @@ class OrganizationResolver
   end
 
   def source_names
-    @organization.contributing_sources.map(&:source)
+    @organization.contributing_sources.map(&:name)
   end
 
   def tag_names

--- a/app/models/organization_tag.rb
+++ b/app/models/organization_tag.rb
@@ -5,7 +5,7 @@ class OrganizationTag < ApplicationRecord
   belongs_to :tag
   validates_uniqueness_of :tag, scope: :organization
 
-  has_paper_trail ignore: %i[created_at updated_at]
+  include Auditable
 
   def self.apply(tag_names, organization)
     Array(tag_names).each do |tag_name|

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,6 +1,6 @@
 class PhoneNumber < ApplicationRecord
   belongs_to :organization
   validates :content, presence: true
-  has_paper_trail ignore: %i[created_at updated_at]
   include Rankable
+  include Auditable
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -3,6 +3,6 @@ class Website < ApplicationRecord
   validates :organization, presence: true
   validates :content, presence: true, uniqueness: true
   validates_format_of :content, with: /\./
-  has_paper_trail ignore: %i[created_at updated_at]
   include Rankable
+  include Auditable
 end

--- a/lib/tasks/redshift.rake
+++ b/lib/tasks/redshift.rake
@@ -27,7 +27,8 @@ namespace :redshift do
           organization_name character varying, \
           phone_number character varying, \
           tag_names character varying, \
-          website character varying \
+          website character varying, \
+          source character varying \
         )"
       )
     end

--- a/spec/models/csv_converter_spec.rb
+++ b/spec/models/csv_converter_spec.rb
@@ -14,7 +14,8 @@ describe CsvConverter do
         organization_name: 'Gallery A',
         phone_number: '1-800-123-4567',
         tag_names: 'design,modern',
-        website: 'http://example.com'
+        website: 'http://example.com',
+        sources: 'ArtMagazine,SpiderMania'
       }
 
       converted = CsvConverter.convert input

--- a/spec/models/organization_resolver_spec.rb
+++ b/spec/models/organization_resolver_spec.rb
@@ -4,7 +4,15 @@ describe OrganizationResolver do
   describe '.resolve' do
     context 'with no related data' do
       it 'returns only the organization id' do
-        organization = Fabricate :organization
+        source = Fabricate :source
+        import = Fabricate :import, source: source
+        raw_input = Fabricate :raw_input, import: import
+        organization = nil
+
+        PaperTrail.track_changes_with(raw_input) do
+          organization = Fabricate :organization
+        end
+
         resolved = OrganizationResolver.resolve organization
         expect(resolved).to eq(
           {
@@ -70,7 +78,8 @@ describe OrganizationResolver do
             organization_name: organization_name,
             phone_number: phone_number,
             tag_names: tag_names,
-            website: website
+            website: website,
+            sources: [source.name]
           }
         )
       end
@@ -145,7 +154,8 @@ describe OrganizationResolver do
             organization_name: organization_name,
             phone_number: phone_number,
             tag_names: [first_tag_name, second_tag_name].join(','),
-            website: website
+            website: website,
+            sources: [source.name]
           }
         )
       end
@@ -233,7 +243,8 @@ describe OrganizationResolver do
             organization_name: organization_name,
             phone_number: phone_number,
             tag_names: [first_tag_name, second_tag_name].join(','),
-            website: website
+            website: website,
+            sources: Source.all.map(&:name)
           }
         )
       end

--- a/spec/models/organization_resolver_spec.rb
+++ b/spec/models/organization_resolver_spec.rb
@@ -17,6 +17,7 @@ describe OrganizationResolver do
         expect(resolved).to eq(
           {
             bearden_id: organization.id,
+            sources: [source.name],
             tag_names: ''
           }
         )

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -15,4 +15,83 @@ describe Organization do
       )
     end
   end
+
+  context '#contributing_sources' do
+    context 'with a single source' do
+      it 'responds with a single source name' do
+        source = Fabricate :source
+        import = Fabricate(
+          :import,
+          source: source,
+          transformer: CsvTransformer
+        )
+
+        org = nil
+
+        PaperTrail.track_changes_with(import) do
+          org = Fabricate :organization
+          org.emails.create! content: 'foo@mail'
+          org.locations.create! content: 'Testing Way, Specvill'
+          org.organization_names.create! content: 'Foo 2'
+          org.tags.create! name: 'Bar tag'
+          org.phone_numbers.create! content: '555-884-2001'
+        end
+
+        sources = org.contributing_sources
+        expect(sources).to eq [source]
+      end
+    end
+
+    context 'with multiple and different sources' do
+      it 'responds with an array of their unique source names' do
+        source1 = Fabricate :source
+        source2 = Fabricate :source
+        source3 = Fabricate :source
+
+        import1 = Fabricate(
+          :import,
+          source: source1,
+          transformer: CsvTransformer
+        )
+
+        import2 = Fabricate(
+          :import,
+          source: source2,
+          transformer: CsvTransformer
+        )
+
+        import3 = Fabricate(
+          :import,
+          source: source3,
+          transformer: CsvTransformer
+        )
+
+        org = nil
+
+        PaperTrail.track_changes_with(import1) do
+          org = Fabricate :organization
+        end
+
+        PaperTrail.track_changes_with(import2) do
+          org.emails.create! content: 'foo@mail'
+          org.locations.create! content: 'Testing Way, Specvill'
+          org.organization_names.create! content: 'Foo 2'
+          org.tags.create! name: 'Bar tag'
+          org.phone_numbers.create! content: '555-884-2001'
+        end
+
+        PaperTrail.track_changes_with(import3) do
+          org.emails.create! content: 'bar@mail'
+          org.locations.create! content: 'Testing Way, Specvill'
+          org.organization_names.create! content: 'Foo 3'
+          org.tags.create! name: 'Bar tag'
+          org.phone_numbers.create! content: '555-884-2001'
+        end
+
+        sources = org.contributing_sources
+        expect(sources.count).to eq 3
+        expect(sources).to match_array([source1, source2, source3])
+      end
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -22,13 +22,13 @@ describe Organization do
         source = Fabricate :source
         import = Fabricate(
           :import,
-          source: source,
-          transformer: CsvTransformer
+          source: source
         )
+        raw_input = Fabricate :raw_input, import: import
 
         org = nil
 
-        PaperTrail.track_changes_with(import) do
+        PaperTrail.track_changes_with(raw_input) do
           org = Fabricate :organization
           org.emails.create! content: 'foo@mail'
           org.locations.create! content: 'Testing Way, Specvill'
@@ -48,31 +48,28 @@ describe Organization do
         source2 = Fabricate :source
         source3 = Fabricate :source
 
-        import1 = Fabricate(
-          :import,
-          source: source1,
-          transformer: CsvTransformer
+        raw_input1 = Fabricate(
+          :raw_input,
+          import: Fabricate(:import, source: source1)
         )
 
-        import2 = Fabricate(
-          :import,
-          source: source2,
-          transformer: CsvTransformer
+        raw_input2 = Fabricate(
+          :raw_input,
+          import: Fabricate(:import, source: source2)
         )
 
-        import3 = Fabricate(
-          :import,
-          source: source3,
-          transformer: CsvTransformer
+        raw_input3 = Fabricate(
+          :raw_input,
+          import: Fabricate(:import, source: source3)
         )
 
         org = nil
 
-        PaperTrail.track_changes_with(import1) do
+        PaperTrail.track_changes_with(raw_input1) do
           org = Fabricate :organization
         end
 
-        PaperTrail.track_changes_with(import2) do
+        PaperTrail.track_changes_with(raw_input2) do
           org.emails.create! content: 'foo@mail'
           org.locations.create! content: 'Testing Way, Specvill'
           org.organization_names.create! content: 'Foo 2'
@@ -80,7 +77,7 @@ describe Organization do
           org.phone_numbers.create! content: '555-884-2001'
         end
 
-        PaperTrail.track_changes_with(import3) do
+        PaperTrail.track_changes_with(raw_input3) do
           org.emails.create! content: 'bar@mail'
           org.locations.create! content: 'Testing Way, Specvill'
           org.organization_names.create! content: 'Foo 3'


### PR DESCRIPTION
NOTE: This PR changes the Redshift schema.

This PR adds a `sources` field to our CSV export. The goal is to export a new field that contains a list of  all the record's sources, ie, `'Source Foo', 'Source Bar', 'Source Qux'`. These sources can come from an `organization`, a `phone_number`, a `location`, and so on. We provide this list as an easy-ish way for end users to query records which contain a given source.

A new module, `Auditable`, fell out of the refactor. All modules that implement PaperTrail now do so via Auditable. This simplified our models and gave us an added method `model.sources`, which returns all the model's source objects. Previously, these were a pain to call: `organization.emails.first.versions.first.actor.source`. Now you can simply use `organization.emails.first.sources`. Additionally, you can call all an organization's related sources with `organization.contributing_sources`.

One thing that this PR brought up in conversations with @jonallured is, why do we have PaperTrail in the first place when we don't actually edit/update records? 

There is currently no way that an email or a phone number, for instance, would ever be updated. So, what's the value? Well, in a speculative future, if this app adds user CRUD, then it will possibly be possible to update an email or a phone number*. And in that case, our example of an email would have multiple sources, and seeing who changed what will be helpful. This future, however, imagines an "artisanal" dataset, in contrast to our current approach, which is focused more on quantity.

Closes https://github.com/artsy/bearden/issues/182

*Full disclosure: I'm into not ever updating data, instead opting for append-only.