### PR TITLE
Clean up the uploads created during the test run

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter = :inline
     example.run
     ActiveJob::Base.queue_adapter = original_adapter
+    carrier_wave_dir = File.join S3Uploader.root.call, S3Uploader.store_dir
+    FileUtils.rm_rf(carrier_wave_dir)
   end
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Inspired by:

https://github.com/carrierwaveuploader/carrierwave/wiki/how-to:-cleanup-after-your-rspec-tests

But my take was a little less involved. 😉 

Also: how weird is it that `S3Uploader.root` returns a `Proc`??

closes #174