### PR TITLE
Remove Geocoder as Source

### DIFF
--- a/app/models/auditable.rb
+++ b/app/models/auditable.rb
@@ -6,6 +6,10 @@ module Auditable
   end
 
   def sources
-    versions.map { |version| version.actor.import.source }
+    actors.select { |actor| actor.respond_to?(:source) }.map(&:source)
+  end
+
+  def actors
+    versions.map(&:actor)
   end
 end

--- a/app/models/rankable.rb
+++ b/app/models/rankable.rb
@@ -6,6 +6,6 @@ module Rankable
   def rank
     raw_input = versions.first&.actor
     return nil unless raw_input
-    raw_input.import.source.rank_for rank_type
+    raw_input.source.rank_for rank_type
   end
 end

--- a/app/models/raw_input.rb
+++ b/app/models/raw_input.rb
@@ -5,6 +5,8 @@ class RawInput < ApplicationRecord
   UPDATED = 'updated'.freeze
   ERROR = 'error'.freeze
 
+  delegate :source, to: :import
+
   def transform
     import.transformer.constantize.transform self
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,8 +5,7 @@ ranks = %i[
 [
   { name: 'Factual', rank: 1 },
   { name: 'HumanOutsourcer', rank: 2 },
-  { name: 'Geocoder', rank: 3 },
-  { name: 'Burden', rank: 4 }
+  { name: 'Burden', rank: 3 }
 ].each do |source|
   source_attrs = ranks.each_with_object({}) do |key, memo|
     memo[key] = source[:rank]

--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -1,8 +1,4 @@
 desc 'Create coordinates for records that are not geocoded'
 task geocode_locations: :environment do
-  source = Source.find_by name: 'Geocoder'
-  description = "Geocoded by rake task on #{DateTime.now}"
-  import = source.imports.create description: description
-  GeocodeLocationJob.perform_now import.id
-  puts 'Starting background process to geocode locations ...'
+  GeocodeLocationJob.perform_now
 end

--- a/spec/jobs/geocode_location_job_spec.rb
+++ b/spec/jobs/geocode_location_job_spec.rb
@@ -23,10 +23,9 @@ describe GeocodeLocationJob do
         content: 'New York City', latitude: 1234, longitude: 5678
       )
       org.locations.create content: '401 Broadway, New York City'
-      import = Fabricate :import
 
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
         assert_performed_jobs 2
       end
 
@@ -43,11 +42,10 @@ describe GeocodeLocationJob do
       org.locations.create(
         content: 'New York City', latitude: 1234, longitude: nil
       )
-      import = Fabricate :import
 
       perform_enqueued_jobs do
         expect do
-          GeocodeLocationJob.perform_later import.id
+          GeocodeLocationJob.perform_later
         end.to raise_error Geocoder::OverQueryLimitError
       end
     end
@@ -56,10 +54,9 @@ describe GeocodeLocationJob do
       org = Fabricate :organization
       org.locations.create content: 'Berlin, Germany'
       org.locations.create content: '401 Broadway, New York City'
-      import = Fabricate :import
 
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
         assert_performed_jobs 3
       end
     end
@@ -70,10 +67,9 @@ describe GeocodeLocationJob do
       org.locations.create(
         content: 'New York City', latitude: 1234, longitude: 5678
       )
-      import = Fabricate :import
 
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
         assert_performed_jobs 2
       end
     end
@@ -84,10 +80,9 @@ describe GeocodeLocationJob do
       org.locations.create(
         content: 'New York City', latitude: 1234, longitude: 5678
       )
-      import = Fabricate :import
 
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
         assert_performed_jobs 2
         assert_enqueued_jobs 0
       end
@@ -101,10 +96,9 @@ describe GeocodeLocationJob do
 
       org = Fabricate :organization
       org.locations.create content: 'Nil Town, USA'
-      import = Fabricate :import
 
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
       end
 
       expect(org.locations.first.latitude).to eql fallback_coordinates[0]
@@ -118,22 +112,15 @@ describe GeocodeLocationJob do
       Fabricate :location, latitude: nil, organization: organization
       Fabricate :location, latitude: nil, organization: organization
 
-      source = Fabricate :source, name: 'Foo Geocoding, Inc.'
-      description = 'Testing, testing'
-      import = Fabricate :import, source: source, description: description
-
       perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later import.id
+        GeocodeLocationJob.perform_later
 
         assert_performed_jobs 3
-        expect(Source.count).to eql 1
         expect(Location.count).to eql 2
 
         Location.all.each do |location|
           actor = location.versions.last.actor
-          expect(actor).to eq import
-          expect(actor.description).to eq description
-          expect(actor.source).to eq source
+          expect(actor).to eq 'Geocoder'
         end
       end
     end


### PR DESCRIPTION
Early in the project's life, we assumed Geocoder would be a Source, but
that's not really true.