### PR TITLE
Fix: work around unsupported server compression

### DIFF
--- a/app/models/website_resolver.rb
+++ b/app/models/website_resolver.rb
@@ -43,6 +43,7 @@ class WebsiteResolver
 
     @connection ||= Faraday.new do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects, redirect_options
+      faraday.headers['Accept-Encoding'] = 'none'
       faraday.adapter Faraday.default_adapter
     end
   end


### PR DESCRIPTION
@madelineb ran into a few situations where a `RawInput` would blow up with
the `Zlib::DataError` exception. Some research turned up this GitHub
Issue:

https://github.com/lostisland/faraday/issues/120

So all this commit does is set that header hoping that it will mean
servers stop using an unsupported compression method.