### PR TITLE
Add new temporary worker for debugging #AddNewDyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma
-worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY}
+worker_default: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY} -q default
+worker_debug: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY} -q debug

--- a/app/jobs/finalize_import_job.rb
+++ b/app/jobs/finalize_import_job.rb
@@ -1,6 +1,8 @@
 class FinalizeImportJob < ApplicationJob
   attr_reader :import
 
+  queue_as :default
+
   def perform(import_id)
     @import = Import.find_by id: import_id
     return unless import

--- a/app/jobs/finish_sync_job.rb
+++ b/app/jobs/finish_sync_job.rb
@@ -1,6 +1,8 @@
 class FinishSyncJob < ApplicationJob
   attr_accessor :sync
 
+  queue_as :default
+
   def perform(sync_id)
     @sync = Sync.find_by id: sync_id
     return unless sync

--- a/app/jobs/geocode_location_job.rb
+++ b/app/jobs/geocode_location_job.rb
@@ -1,4 +1,6 @@
 class GeocodeLocationJob < ApplicationJob
+  queue_as :default
+
   JOB_DELAY = 0.2.seconds
   FALLBACK_COORDINATES = [0.0, 0.0].freeze
   FALLBACK_COUNTRY = nil

--- a/app/jobs/organization_export_job.rb
+++ b/app/jobs/organization_export_job.rb
@@ -1,7 +1,7 @@
 class OrganizationExportJob < ApplicationJob
   PART_SIZE = Rails.application.secrets.batch_export_size
 
-  queue_as :default
+  queue_as :debug
 
   attr_accessor :sync, :part_number, :part_size
 

--- a/app/jobs/organization_export_job.rb
+++ b/app/jobs/organization_export_job.rb
@@ -1,6 +1,8 @@
 class OrganizationExportJob < ApplicationJob
   PART_SIZE = Rails.application.secrets.batch_export_size
 
+  queue_as :default
+
   attr_accessor :sync, :part_number, :part_size
 
   def perform(sync_id, part_number)

--- a/app/jobs/parse_csv_import_job.rb
+++ b/app/jobs/parse_csv_import_job.rb
@@ -5,6 +5,8 @@ require 'charlock_holmes/string'
 class ParseCsvImportJob < ApplicationJob
   attr_accessor :import
 
+  queue_as :default
+
   def perform(import_id)
     @import = Import.find_by id: import_id
     return unless @import

--- a/app/jobs/raw_input_transform_job.rb
+++ b/app/jobs/raw_input_transform_job.rb
@@ -1,5 +1,5 @@
 class RawInputTransformJob < ApplicationJob
-  queue_as :default
+  queue_as :debug
 
   def perform(import_id)
     import = Import.find_by id: import_id

--- a/app/jobs/raw_input_transform_job.rb
+++ b/app/jobs/raw_input_transform_job.rb
@@ -1,4 +1,6 @@
 class RawInputTransformJob < ApplicationJob
+  queue_as :default
+
   def perform(import_id)
     import = Import.find_by id: import_id
     return unless import

--- a/app/jobs/raw_input_transform_job.rb
+++ b/app/jobs/raw_input_transform_job.rb
@@ -1,5 +1,5 @@
 class RawInputTransformJob < ApplicationJob
-  queue_as :debug
+  queue_as :default
 
   def perform(import_id)
     import = Import.find_by id: import_id

--- a/app/jobs/start_sync_job.rb
+++ b/app/jobs/start_sync_job.rb
@@ -2,6 +2,8 @@ class StartSyncJob < ApplicationJob
   attr_accessor :sync
   attr_reader :part_size
 
+  queue_as :default
+
   def self.force_sync
     sync = Sync.create state: SyncMicroMachine::STARTING
     perform_later sync.id, force: true

--- a/app/jobs/sync_management_job.rb
+++ b/app/jobs/sync_management_job.rb
@@ -1,4 +1,6 @@
 class SyncManagementJob < ApplicationJob
+  queue_as :default
+
   def perform
     sync = Sync.where(state: SyncMicroMachine.in_progress_states).first
 


### PR DESCRIPTION
This PR sets up a new worker (`worker_debug`). The idea is to split jobs between the two dynos to get a better diagnosis on memory issues. 