### PR TITLE
Add '.csv' to files uploaded to S3

### DIFF
--- a/app/jobs/finish_sync_job.rb
+++ b/app/jobs/finish_sync_job.rb
@@ -23,7 +23,7 @@ class FinishSyncJob < ApplicationJob
   def sources
     (1..sync.total_parts).map do |part|
       bucket_name = Rails.application.secrets.aws_bucket
-      key = "#{sync.export_folder}/#{part}"
+      key = "#{sync.export_folder}/#{part}.csv"
       "s3://#{bucket_name}/#{key}"
     end
   end

--- a/spec/jobs/finish_sync_job_spec.rb
+++ b/spec/jobs/finish_sync_job_spec.rb
@@ -4,7 +4,7 @@ describe FinishSyncJob do
   describe '#perform' do
     context 'with successful reset' do
       it 'resets the data warehouse, updates the imports, posts to Slack and updates the Sync' do # rubocop:disable Metrics/LineLength
-        sources = ['s3://testing/folder/timestamp/1']
+        sources = ['s3://testing/folder/timestamp/1.csv']
         result = double(
           :result,
           success?: true,


### PR DESCRIPTION
Seein' if this might fix our dupes bug. I'm skeptical, but at least it'll be an accurate filename.