### PR TITLE
Add a type for organizations

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -7,6 +7,7 @@ class SourcesController < ApplicationController
       email_rank: Source.order(:email_rank),
       location_rank: Source.order(:location_rank),
       organization_name_rank: Source.order(:organization_name_rank),
+      organization_type_rank: Source.order(:organization_type_rank),
       phone_number_rank: Source.order(:phone_number_rank),
       website_rank: Source.order(:website_rank)
     }
@@ -38,6 +39,7 @@ class SourcesController < ApplicationController
       :email_rank,
       :location_rank,
       :organization_name_rank,
+      :organization_type_rank,
       :phone_number_rank,
       :website_rank
     )

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -1,0 +1,3 @@
+class TypesController < ApplicationController
+  expose(:type_names) { Type.order(:name).pluck(:name) }
+end

--- a/app/models/csv_converter.rb
+++ b/app/models/csv_converter.rb
@@ -11,6 +11,7 @@ class CsvConverter
       location
       longitude
       organization_name
+      organization_type
       phone_number
       tag_names
       website
@@ -39,6 +40,7 @@ class CsvConverter
       @input[:location],
       @input[:longitude],
       @input[:organization_name],
+      @input[:organization_type],
       @input[:phone_number],
       @input[:tag_names],
       @input[:website],

--- a/app/models/csv_transformer.rb
+++ b/app/models/csv_transformer.rb
@@ -10,6 +10,7 @@ class CsvTransformer
       latitude
       longitude
       organization_name
+      organization_type
       phone_number
       tag_names
       website
@@ -30,6 +31,7 @@ class CsvTransformer
       organization: organization_attrs,
       location: location_attrs,
       organization_name: organization_name_attrs,
+      organization_type: organization_type_attrs,
       phone_number: phone_number_attrs,
       tag_names: tag_names,
       website: website_attrs
@@ -63,6 +65,12 @@ class CsvTransformer
   def organization_name_attrs
     {
       content: @data['organization_name'].presence
+    }.compact
+  end
+
+  def organization_type_attrs
+    {
+      content: @data['organization_type'].presence
     }.compact
   end
 

--- a/app/models/import_errors.rb
+++ b/app/models/import_errors.rb
@@ -43,20 +43,33 @@ class ImportErrors
   end
 
   def errors_from_details(details)
-    errors = rankeable_errors(details) + tag_errors(details)
+    errors = rankeable_errors(details) + overridden_errors(details)
     errors.compact.join(', ')
   end
 
   def rankeable_errors(details)
     details.flat_map do |field, detail|
-      next if field == 'tags'
+      next if overridden_error_fields.include?(field)
       errors = detail['content'].pluck('error')
       errors.flat_map { |error| [field, error].join(' ') }
     end
   end
 
+  def overridden_error_fields
+    %w[tags organization_type]
+  end
+
+  def overridden_errors(details)
+    tag_errors(details) + organization_type_error(details)
+  end
+
   def tag_errors(details)
     return [] unless details.key?('tags')
     [details['tags'].split(':').first]
+  end
+
+  def organization_type_error(details)
+    return [] unless details.key?('organization_type')
+    ['organization type not found']
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,7 @@ class Organization < ApplicationRecord
   has_many :locations
   has_many :organization_names
   has_many :organization_tags
+  has_many :organization_types
   has_many :phone_numbers
   has_many :tags, through: :organization_tags
   has_many :websites

--- a/app/models/organization_resolver.rb
+++ b/app/models/organization_resolver.rb
@@ -20,6 +20,7 @@ class OrganizationResolver
     @email = find_highest_rankable(@organization.emails)
     @location = find_highest_rankable(@organization.locations)
     @organization_name = find_highest_rankable(@organization.organization_names)
+    @organization_type = find_highest_rankable(@organization.organization_types)
     @phone_number = find_highest_rankable(@organization.phone_numbers)
     @website = find_highest_rankable(@organization.websites)
   end
@@ -40,6 +41,7 @@ class OrganizationResolver
       location: @location&.content,
       longitude: @location&.longitude,
       organization_name: @organization_name&.content,
+      organization_type: @organization_type&.name,
       phone_number: @phone_number&.content,
       tag_names: truncated(tag_names),
       website: @website&.content,

--- a/app/models/organization_type.rb
+++ b/app/models/organization_type.rb
@@ -1,0 +1,14 @@
+class OrganizationType < ApplicationRecord
+  belongs_to :organization
+  belongs_to :type
+
+  include Auditable
+  include Rankable
+
+  delegate :name, to: :type
+
+  def content=(value)
+    type = Type.find_by name: value
+    self.type = type
+  end
+end

--- a/app/models/raw_input_changes.rb
+++ b/app/models/raw_input_changes.rb
@@ -1,7 +1,13 @@
 class RawInputChanges
   class InvalidData < StandardError; end
 
-  VALID_RELATIONS = %i[email location organization_name phone_number].freeze
+  VALID_RELATIONS = %i[
+    email
+    location
+    organization_name
+    organization_type
+    phone_number
+  ].freeze
 
   def self.apply(raw_input)
     new(raw_input).apply

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -6,6 +6,7 @@ class Source < ApplicationRecord
   validates :email_rank, presence: true, uniqueness: true
   validates :location_rank, presence: true, uniqueness: true
   validates :organization_name_rank, presence: true, uniqueness: true
+  validates :organization_type_rank, presence: true, uniqueness: true
   validates :phone_number_rank, presence: true, uniqueness: true
   validates :website_rank, presence: true, uniqueness: true
 
@@ -14,6 +15,7 @@ class Source < ApplicationRecord
       email_rank: email_rank,
       location_rank: location_rank,
       organization_name_rank: organization_name_rank,
+      organization_type_rank: organization_type_rank,
       phone_number_rank: phone_number_rank,
       website_rank: website_rank
     }

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -1,0 +1,5 @@
+class Type < ApplicationRecord
+  has_many :organization_types
+  has_many :organizations, through: :organization_types
+  validates :name, presence: true
+end

--- a/app/views/imports/new.html.haml
+++ b/app/views/imports/new.html.haml
@@ -57,6 +57,10 @@
           %td <a href="/tags" target="_blank">art, photography, gallery</a>
           %td No
         %tr
+          %td <code>organization_type</code>
+          %td <a href="/types" target="_blank">gallery</a>
+          %td No
+        %tr
           %td <code>in_business</code>
           %td false
           %td No

--- a/app/views/imports/new.html.haml
+++ b/app/views/imports/new.html.haml
@@ -54,11 +54,11 @@
           %td No
         %tr
           %td <code>tag_names</code>
-          %td <a href="/tags" target="_blank">art, photography, gallery</a>
+          %td= link_to 'art, photography, contemporary', '/tags', target: :_blank
           %td No
         %tr
           %td <code>organization_type</code>
-          %td <a href="/types" target="_blank">gallery</a>
+          %td= link_to 'gallery', '/types', target: :_blank
           %td No
         %tr
           %td <code>in_business</code>

--- a/app/views/sources/_form.html.haml
+++ b/app/views/sources/_form.html.haml
@@ -3,7 +3,7 @@
     = f.label :name
     = f.text_field :name, { class: 'form-control', required: true }
 
-  - for type in [:email_rank, :location_rank, :organization_name_rank, :phone_number_rank, :website_rank]
+  - for type in [:email_rank, :location_rank, :organization_name_rank, :organization_type_rank, :phone_number_rank, :website_rank]
     .form-group
       = f.label type
       = f.select(type, source_rank_options(type), {}, { class: 'form-control' })

--- a/app/views/types/index.html.haml
+++ b/app/views/types/index.html.haml
@@ -1,0 +1,5 @@
+%h1 Types
+
+%ul
+  - for name in type_names
+    %li= name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   resources :sources, only: %i[create edit index new update]
   resources :syncs, only: :index
   resources :tags, only: :index
+  resources :types, only: :index
 end

--- a/db/migrate/20170503151504_create_types.rb
+++ b/db/migrate/20170503151504_create_types.rb
@@ -1,0 +1,8 @@
+class CreateTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :types do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170503152238_create_organization_types.rb
+++ b/db/migrate/20170503152238_create_organization_types.rb
@@ -1,0 +1,9 @@
+class CreateOrganizationTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :organization_types do |t|
+      t.belongs_to :organization
+      t.belongs_to :type
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170503181936_add_organization_type_rank_to_sources.rb
+++ b/db/migrate/20170503181936_add_organization_type_rank_to_sources.rb
@@ -1,0 +1,5 @@
+class AddOrganizationTypeRankToSources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :sources, :organization_type_rank, :integer
+  end
+end

--- a/lib/tasks/redshift.rake
+++ b/lib/tasks/redshift.rake
@@ -31,6 +31,7 @@ namespace :redshift do
           longitude double precision, \
           location character varying, \
           organization_name character varying, \
+          organization_type character varying, \
           phone_number character varying, \
           tag_names character varying, \
           website character varying, \

--- a/spec/fabricators/organization_type_fabricator.rb
+++ b/spec/fabricators/organization_type_fabricator.rb
@@ -1,0 +1,2 @@
+Fabricator :organization_type do
+end

--- a/spec/fabricators/source_fabricator.rb
+++ b/spec/fabricators/source_fabricator.rb
@@ -3,6 +3,7 @@ Fabricator :source do
   email_rank { Fabricate.sequence(:email_rank, 1) }
   location_rank { Fabricate.sequence(:location_rank, 1) }
   organization_name_rank { Fabricate.sequence(:organization_name_rank, 1) }
+  organization_type_rank { Fabricate.sequence(:organization_type_rank, 1) }
   phone_number_rank { Fabricate.sequence(:phone_number_rank, 1) }
   website_rank { Fabricate.sequence(:website_rank, 1) }
 end

--- a/spec/fabricators/type_fabricator.rb
+++ b/spec/fabricators/type_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator :type do
+  name { Fabricate.sequence(:type_name) { |i| "type ##{i}" } }
+end

--- a/spec/features/create_source_spec.rb
+++ b/spec/features/create_source_spec.rb
@@ -15,6 +15,7 @@ feature 'Create Source' do
       select '1 - add to end', from: 'Email rank'
       select '1 - add to end', from: 'Location rank'
       select '1 - add to end', from: 'Organization name rank'
+      select '1 - add to end', from: 'Organization type rank'
       select '1 - add to end', from: 'Phone number rank'
       select '1 - add to end', from: 'Website rank'
 
@@ -24,6 +25,7 @@ feature 'Create Source' do
       expect(source.email_rank).to eq 1
       expect(source.location_rank).to eq 1
       expect(source.organization_name_rank).to eq 1
+      expect(source.organization_type_rank).to eq 1
       expect(source.phone_number_rank).to eq 1
       expect(source.website_rank).to eq 1
     end
@@ -34,6 +36,7 @@ feature 'Create Source' do
         email_rank: 1,
         location_rank: 1,
         organization_name_rank: 1,
+        organization_type_rank: 1,
         phone_number_rank: 1,
         website_rank: 1
       )
@@ -45,6 +48,7 @@ feature 'Create Source' do
       select "1 - insert above #{source.name}", from: 'Email rank'
       select "1 - insert above #{source.name}", from: 'Location rank'
       select "1 - insert above #{source.name}", from: 'Organization name rank'
+      select "1 - insert above #{source.name}", from: 'Organization type rank'
       select "1 - insert above #{source.name}", from: 'Phone number rank'
       select "1 - insert above #{source.name}", from: 'Website rank'
 
@@ -53,6 +57,7 @@ feature 'Create Source' do
       expect(source.reload.email_rank).to eq 2
       expect(source.location_rank).to eq 2
       expect(source.organization_name_rank).to eq 2
+      expect(source.organization_type_rank).to eq 2
       expect(source.phone_number_rank).to eq 2
       expect(source.website_rank).to eq 2
 
@@ -60,6 +65,7 @@ feature 'Create Source' do
       expect(new_source.email_rank).to eq 1
       expect(new_source.location_rank).to eq 1
       expect(new_source.organization_name_rank).to eq 1
+      expect(new_source.organization_type_rank).to eq 1
       expect(new_source.phone_number_rank).to eq 1
       expect(new_source.website_rank).to eq 1
     end

--- a/spec/features/csv_import_spec.rb
+++ b/spec/features/csv_import_spec.rb
@@ -19,6 +19,7 @@ feature 'CSV Import' do
 
     Fabricate :tag, name: 'design'
     Fabricate :tag, name: 'modern'
+    Fabricate :type, name: 'gallery'
     source = Fabricate :source, name: 'Factual'
 
     visit '/imports/new'

--- a/spec/features/edit_sources_spec.rb
+++ b/spec/features/edit_sources_spec.rb
@@ -10,14 +10,7 @@ feature 'Edit Source' do
     let(:is_admin) { true }
 
     scenario 'Admins have access to edit a source' do
-      Fabricate(
-        :source,
-        email_rank: 1,
-        location_rank: 1,
-        organization_name_rank: 1,
-        phone_number_rank: 1,
-        website_rank: 1
-      )
+      Fabricate(:source)
 
       allow_any_instance_of(ApplicationController)
         .to receive(:user).and_return(
@@ -36,14 +29,7 @@ feature 'Edit Source' do
     let(:is_admin) { false }
 
     scenario 'Non-admins do not have access to create a new source' do
-      Fabricate(
-        :source,
-        email_rank: 1,
-        location_rank: 1,
-        organization_name_rank: 1,
-        phone_number_rank: 1,
-        website_rank: 1
-      )
+      Fabricate(:source)
       visit '/sources'
       expect(page).to_not have_css 'a.edit'
     end
@@ -62,6 +48,7 @@ feature 'Edit Source' do
         email_rank: 1,
         location_rank: 1,
         organization_name_rank: 1,
+        organization_type_rank: 1,
         phone_number_rank: 1,
         website_rank: 1
       )
@@ -71,6 +58,7 @@ feature 'Edit Source' do
         email_rank: 2,
         location_rank: 2,
         organization_name_rank: 2,
+        organization_type_rank: 2,
         phone_number_rank: 2,
         website_rank: 2
       )
@@ -84,6 +72,7 @@ feature 'Edit Source' do
       select first_option, from: 'Email rank'
       select first_option, from: 'Location rank'
       select first_option, from: 'Organization name rank'
+      select first_option, from: 'Organization type rank'
       select first_option, from: 'Phone number rank'
       select first_option, from: 'Website rank'
 
@@ -93,6 +82,7 @@ feature 'Edit Source' do
       expect(source_b.email_rank).to eq 1
       expect(source_b.location_rank).to eq 1
       expect(source_b.organization_name_rank).to eq 1
+      expect(source_b.organization_type_rank).to eq 1
       expect(source_b.phone_number_rank).to eq 1
       expect(source_b.website_rank).to eq 1
     end

--- a/spec/features/list_sources_spec.rb
+++ b/spec/features/list_sources_spec.rb
@@ -29,6 +29,7 @@ feature 'List Sources' do
         email_rank: 1,
         location_rank: 2,
         organization_name_rank: 1,
+        organization_type_rank: 3,
         phone_number_rank: 1,
         website_rank: 3
       )
@@ -39,6 +40,7 @@ feature 'List Sources' do
         email_rank: 3,
         location_rank: 1,
         organization_name_rank: 2,
+        organization_type_rank: 2,
         phone_number_rank: 2,
         website_rank: 1
       )
@@ -49,6 +51,7 @@ feature 'List Sources' do
         email_rank: 2,
         location_rank: 3,
         organization_name_rank: 3,
+        organization_type_rank: 1,
         phone_number_rank: 3,
         website_rank: 2
       )
@@ -65,6 +68,7 @@ feature 'List Sources' do
           'Source 1',
           'Source 2',
           'Source 1',
+          'Source 3',
           'Source 1',
           'Source 2'
         ]
@@ -77,6 +81,7 @@ feature 'List Sources' do
           'Source 1',
           'Source 2',
           'Source 2',
+          'Source 2',
           'Source 3'
         ]
       )
@@ -87,6 +92,7 @@ feature 'List Sources' do
           'Source 2',
           'Source 3',
           'Source 3',
+          'Source 1',
           'Source 3',
           'Source 1'
         ]

--- a/spec/features/list_types_spec.rb
+++ b/spec/features/list_types_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+feature 'List Types' do
+  scenario 'Importer views list of types' do
+    type_names = %w[gallery museum not_art_org]
+    type_names.each { |name| Fabricate :type, name: name }
+    visit '/types'
+    type_names.each { |name| expect(page).to have_text name }
+  end
+end

--- a/spec/fixtures/one_complete_gallery.csv
+++ b/spec/fixtures/one_complete_gallery.csv
@@ -1,2 +1,2 @@
-email,city,country,location,latitude,longitude,organization_name,phone_number,tag_names,website
-info@example.com,new york,USA,123 main street,70.0,30.0,example gallery,1-800-777-1234,"design,modern",example.com
+email,city,country,location,latitude,longitude,organization_name,phone_number,tag_names,organization_type,website
+info@example.com,new york,USA,123 main street,70.0,30.0,example gallery,1-800-777-1234,"design,modern",gallery,example.com

--- a/spec/models/csv_converter_spec.rb
+++ b/spec/models/csv_converter_spec.rb
@@ -13,6 +13,7 @@ describe CsvConverter do
         location: '123 main street',
         longitude: 3.45,
         organization_name: 'Gallery A',
+        organization_type: 'gallery',
         phone_number: '1-800-123-4567',
         tag_names: 'design,modern',
         website: 'http://example.com',

--- a/spec/models/csv_transformer_spec.rb
+++ b/spec/models/csv_transformer_spec.rb
@@ -13,6 +13,7 @@ describe CsvTransformer do
           latitude: '',
           longitude: '',
           organization_name: '',
+          organization_type: '',
           phone_number: '',
           tag_names: '',
           website: ''
@@ -105,6 +106,7 @@ describe CsvTransformer do
           latitude: '47.5543105',
           longitude: '7.598538899999999',
           organization_name: 'Best Gallery',
+          organization_type: 'gallery',
           phone_number: '1-800-123-4567',
           tag_names: 'design,modern',
           website: 'http://example.com'
@@ -127,6 +129,9 @@ describe CsvTransformer do
           },
           organization_name: {
             content: data[:organization_name]
+          },
+          organization_type: {
+            content: data[:organization_type]
           },
           phone_number: {
             content: data[:phone_number]

--- a/spec/models/organization_resolver_spec.rb
+++ b/spec/models/organization_resolver_spec.rb
@@ -27,6 +27,7 @@ describe OrganizationResolver do
 
     context 'with one set of data' do
       it 'returns all resolved data' do
+        type = Fabricate :type, name: 'gallery'
         source = Fabricate :source
         import = Fabricate :import, source: source
         raw_input = Fabricate :raw_input, import: import
@@ -39,6 +40,7 @@ describe OrganizationResolver do
         location = '123 main street'
         longitude = 70.0
         organization_name = 'The Best Gallery'
+        organization_type = 'gallery'
         phone_number = '1-800-123-4567'
         tag_names = 'design,modern'
         website = 'http://www.example.com'
@@ -56,6 +58,9 @@ describe OrganizationResolver do
           Fabricate(:organization_name,
                     organization: organization,
                     content: organization_name)
+          Fabricate(:organization_type,
+                    organization: organization,
+                    type: type)
           Fabricate(:phone_number,
                     content: phone_number,
                     organization: organization)
@@ -79,6 +84,7 @@ describe OrganizationResolver do
             location: location,
             longitude: longitude,
             organization_name: organization_name,
+            organization_type: organization_type,
             phone_number: phone_number,
             tag_names: tag_names,
             website: website,
@@ -92,6 +98,7 @@ describe OrganizationResolver do
       it 'breaks ties with created_at - newest wins' do
         organization = nil
 
+        type = Fabricate :type, name: 'gallery'
         source = Fabricate :source
 
         first_import = Fabricate :import, source: source
@@ -116,6 +123,7 @@ describe OrganizationResolver do
         location = '123 main street'
         longitude = 70.0
         organization_name = 'The Best Gallery'
+        organization_type = 'gallery'
         phone_number = '1-800-123-4567'
         website = 'http://www.example.com'
 
@@ -135,6 +143,9 @@ describe OrganizationResolver do
           Fabricate(:organization_name,
                     organization: organization,
                     content: organization_name)
+          Fabricate(:organization_type,
+                    organization: organization,
+                    type: type)
           Fabricate(:phone_number,
                     content: phone_number,
                     organization: organization)
@@ -156,6 +167,7 @@ describe OrganizationResolver do
             location: location,
             longitude: longitude,
             organization_name: organization_name,
+            organization_type: organization_type,
             phone_number: phone_number,
             tag_names: [first_tag_name, second_tag_name].join(','),
             website: website,
@@ -167,6 +179,7 @@ describe OrganizationResolver do
 
     context 'with two sets of data' do
       it 'returns only the highest ranked data' do
+        type = Fabricate :type, name: 'gallery'
         organization = nil
 
         city = 'Tulum'
@@ -176,6 +189,7 @@ describe OrganizationResolver do
         location = '123 main street'
         longitude = 70.0
         organization_name = 'The Best Gallery'
+        organization_type = 'gallery'
         phone_number = '1-800-123-4567'
         website = 'http://www.example.com'
 
@@ -183,6 +197,7 @@ describe OrganizationResolver do
                                  email_rank: 1,
                                  location_rank: 2,
                                  organization_name_rank: 1,
+                                 organization_type_rank: 2,
                                  phone_number_rank: 2,
                                  website_rank: 1)
         first_import = Fabricate :import, source: first_source
@@ -199,6 +214,9 @@ describe OrganizationResolver do
           Fabricate(:organization_name,
                     organization: organization,
                     content: organization_name)
+          Fabricate(:organization_type,
+                    organization: organization,
+                    type: Fabricate(:type))
           Fabricate :phone_number, organization: organization
           tag = Fabricate :tag, name: first_tag_name
           Fabricate :organization_tag, organization: organization, tag: tag
@@ -209,6 +227,7 @@ describe OrganizationResolver do
                                   email_rank: 2,
                                   location_rank: 1,
                                   organization_name_rank: 2,
+                                  organization_type_rank: 1,
                                   phone_number_rank: 1,
                                   website_rank: 2)
         second_import = Fabricate :import, source: second_source
@@ -225,6 +244,9 @@ describe OrganizationResolver do
                     latitude: latitude,
                     longitude: longitude)
           Fabricate :organization_name, organization: organization
+          Fabricate(:organization_type,
+                    organization: organization,
+                    type: type)
           Fabricate(:phone_number,
                     content: phone_number,
                     organization: organization)
@@ -246,6 +268,7 @@ describe OrganizationResolver do
             location: location,
             longitude: longitude,
             organization_name: organization_name,
+            organization_type: organization_type,
             phone_number: phone_number,
             tag_names: [first_tag_name, second_tag_name].join(','),
             website: website,

--- a/spec/models/raw_input_changes_spec.rb
+++ b/spec/models/raw_input_changes_spec.rb
@@ -6,6 +6,7 @@ describe RawInputChanges do
       context 'with valid data' do
         it 'creates that organization and records the state' do
           Fabricate :tag, name: 'design'
+          Fabricate :type, name: 'gallery'
           source = Fabricate :source
           import = Fabricate(:import,
                              source: source,
@@ -18,6 +19,7 @@ describe RawInputChanges do
             latitude: '47.5543105',
             longitude: '7.598538899999999',
             organization_name: 'Best Gallery',
+            organization_type: 'gallery',
             phone_number: '1-800-123-4567',
             tag_names: 'design',
             website: 'http://example.com'
@@ -37,6 +39,7 @@ describe RawInputChanges do
             Organization,
             OrganizationName,
             OrganizationTag,
+            OrganizationType,
             PhoneNumber,
             Website
           ].each do |klass|
@@ -57,6 +60,7 @@ describe RawInputChanges do
       context 'with a nil website' do
         it 'rolls back all records, saves exception and notes the result' do
           Fabricate :tag, name: 'design'
+          Fabricate :type, name: 'gallery'
           source = Fabricate :source
           import = Fabricate(:import,
                              source: source,
@@ -69,6 +73,7 @@ describe RawInputChanges do
             latitude: '47.5543105',
             longitude: '7.598538899999999',
             organization_name: 'Best Gallery',
+            organization_type: 'gallery',
             phone_number: '1-800-123-4567',
             tag_names: 'design',
             website: nil
@@ -98,6 +103,7 @@ describe RawInputChanges do
       context 'with some invalid data' do
         it 'rolls back all records, saves errors and notes the result' do
           Fabricate :tag, name: 'design'
+          Fabricate :type, name: 'gallery'
           source = Fabricate :source
           import = Fabricate(:import,
                              source: source,
@@ -110,6 +116,7 @@ describe RawInputChanges do
             latitude: '47.5543105',
             longitude: '7.598538899999999',
             organization_name: 'Best Gallery',
+            organization_type: 'invalid',
             phone_number: '1-800-123-4567',
             tag_names: 'invalid',
             website: 'http://example.com'
@@ -127,6 +134,7 @@ describe RawInputChanges do
             Organization,
             OrganizationName,
             OrganizationTag,
+            OrganizationType,
             PhoneNumber,
             Website
           ].each do |klass|
@@ -136,6 +144,7 @@ describe RawInputChanges do
           expect(raw_input.error_details).to eq(
             {
               'email' => { 'content' => [{ 'error' => 'invalid', 'value' => 'infoexample.com' }] }, # rubocop:disable Metrics/LineLength
+              'organization_type' => { 'type' => [{ 'error' => 'blank' }] },
               'tags' => 'all tags could not be applied: invalid'
             }
           )

--- a/spec/models/source_resolver_spec.rb
+++ b/spec/models/source_resolver_spec.rb
@@ -9,6 +9,7 @@ describe SourceResolver do
           email_rank: 1,
           location_rank: 1,
           organization_name_rank: 1,
+          organization_type_rank: 1,
           phone_number_rank: 1,
           website_rank: 1
         )
@@ -26,6 +27,7 @@ describe SourceResolver do
           email_rank: 1,
           location_rank: 1,
           organization_name_rank: 1,
+          organization_type_rank: 1,
           phone_number_rank: 1,
           website_rank: 1
         )
@@ -35,6 +37,7 @@ describe SourceResolver do
           email_rank: 2,
           location_rank: 2,
           organization_name_rank: 2,
+          organization_type_rank: 2,
           phone_number_rank: 2,
           website_rank: 2
         )
@@ -44,6 +47,7 @@ describe SourceResolver do
           email_rank: source_a.email_rank,
           location_rank: source_b.location_rank,
           organization_name_rank: 3,
+          organization_type_rank: 3,
           phone_number_rank: source_b.phone_number_rank,
           website_rank: source_a.website_rank
         )
@@ -63,6 +67,10 @@ describe SourceResolver do
         expect(source_a.organization_name_rank).to eq 1
         expect(source_b.organization_name_rank).to eq 2
         expect(source_c.organization_name_rank).to eq 3
+
+        expect(source_a.organization_type_rank).to eq 1
+        expect(source_b.organization_type_rank).to eq 2
+        expect(source_c.organization_type_rank).to eq 3
 
         expect(source_a.phone_number_rank).to eq 1
         expect(source_c.phone_number_rank).to eq 2


### PR DESCRIPTION
I paired with @gnilekaw on this today so not too much of a write up here - we added a new `Rankable` for organization types based on some feedback from artsy/collector-experience#252. To use this new field, you'd provide a CSV like this:

```
website,organization_type
example.com,gallery
```

We would match that type to our notion of `Type` and then create a join record called `OrganizationType` between that and the `Organization`. Then, when it comes time to export the data to Redshift, we resolve an organization's type just like we do with any other `Rankable`.

Note: this PR does nothing about migrating existing tags into types. We'll tackle that in a different way.

closes https://github.com/artsy/collector-experience/issues/252