### PR TITLE
Stop trying to sync when there are PG::Errors

### DIFF
--- a/app/jobs/finish_sync_job.rb
+++ b/app/jobs/finish_sync_job.rb
@@ -29,7 +29,7 @@ class FinishSyncJob < ApplicationJob
   end
 
   def update_syncing_imports(success)
-    outcome = success ? :insync : :failed
+    outcome = success ? :insync : :fail
     Import.where(state: ImportMicroMachine::SYNCING).each(&outcome)
   end
 

--- a/app/jobs/finish_sync_job.rb
+++ b/app/jobs/finish_sync_job.rb
@@ -29,7 +29,7 @@ class FinishSyncJob < ApplicationJob
   end
 
   def update_syncing_imports(success)
-    outcome = success ? :insync : :revert
+    outcome = success ? :insync : :failed
     Import.where(state: ImportMicroMachine::SYNCING).each(&outcome)
   end
 

--- a/app/models/data_warehouse.rb
+++ b/app/models/data_warehouse.rb
@@ -11,7 +11,6 @@ class DataWarehouse
     Result.new.tap do |result|
       Redshift.connect do |connection|
         begin
-          # binding.pry
           warehouse = new(sources, result, connection)
           warehouse.reset
         rescue PG::Error => e

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -38,8 +38,8 @@ class Import < ApplicationRecord
     machine.trigger ImportMicroMachine::INSYNC
   end
 
-  def failed
-    machine.trigger ImportMicroMachine::FAILED
+  def fail
+    machine.trigger ImportMicroMachine::FAIL
   end
 
   private

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -38,8 +38,8 @@ class Import < ApplicationRecord
     machine.trigger ImportMicroMachine::INSYNC
   end
 
-  def revert
-    machine.trigger ImportMicroMachine::REVERT
+  def failed
+    machine.trigger ImportMicroMachine::FAILED
   end
 
   private

--- a/app/models/import_micro_machine.rb
+++ b/app/models/import_micro_machine.rb
@@ -12,7 +12,7 @@ class ImportMicroMachine < MicroMachine
   SYNCING = 'syncing'.freeze
   INSYNC = 'insync'.freeze
   SYNCED = 'synced'.freeze
-  ERRORS = 'errors'.freeze
+  FAIL = 'fail'.freeze
   FAILED = 'failed'.freeze
 
   def self.completed_states
@@ -38,6 +38,6 @@ class ImportMicroMachine < MicroMachine
     self.when(FINISH, FINALIZING => FINISHED)
     self.when(SYNC, FINISHED => SYNCING)
     self.when(INSYNC, SYNCING => SYNCED)
-    self.when(FAILED, SYNCING => ERRORS)
+    self.when(FAIL, SYNCING => FAILED)
   end
 end

--- a/app/models/import_micro_machine.rb
+++ b/app/models/import_micro_machine.rb
@@ -12,10 +12,11 @@ class ImportMicroMachine < MicroMachine
   SYNCING = 'syncing'.freeze
   INSYNC = 'insync'.freeze
   SYNCED = 'synced'.freeze
-  REVERT = 'revert'.freeze
+  ERRORS = 'errors'.freeze
+  FAILED = 'failed'.freeze
 
   def self.completed_states
-    [FINISHED, SYNCING, SYNCED]
+    [FINISHED, SYNCING, SYNCED, FAILED]
   end
 
   def self.valid_states
@@ -37,6 +38,6 @@ class ImportMicroMachine < MicroMachine
     self.when(FINISH, FINALIZING => FINISHED)
     self.when(SYNC, FINISHED => SYNCING)
     self.when(INSYNC, SYNCING => SYNCED)
-    self.when(REVERT, SYNCING => FINISHED)
+    self.when(FAILED, SYNCING => ERRORS)
   end
 end

--- a/spec/jobs/finish_sync_job_spec.rb
+++ b/spec/jobs/finish_sync_job_spec.rb
@@ -33,7 +33,7 @@ describe FinishSyncJob do
         sync = Fabricate :sync, total_parts: 1
         import = Fabricate :import, state: ImportMicroMachine::SYNCING
         FinishSyncJob.new.perform(sync.id)
-        expect(import.reload.state).to eq ImportMicroMachine::ERRORS
+        expect(import.reload.state).to eq ImportMicroMachine::FAILED
       end
     end
   end

--- a/spec/jobs/finish_sync_job_spec.rb
+++ b/spec/jobs/finish_sync_job_spec.rb
@@ -33,7 +33,7 @@ describe FinishSyncJob do
         sync = Fabricate :sync, total_parts: 1
         import = Fabricate :import, state: ImportMicroMachine::SYNCING
         FinishSyncJob.new.perform(sync.id)
-        expect(import.reload.state).to eq ImportMicroMachine::FINISHED
+        expect(import.reload.state).to eq ImportMicroMachine::ERRORS
       end
     end
   end

--- a/spec/models/import_micro_machine_spec.rb
+++ b/spec/models/import_micro_machine_spec.rb
@@ -12,7 +12,7 @@ describe ImportMicroMachine do
         finished
         syncing
         synced
-        errors
+        failed
       ]
     end
   end

--- a/spec/models/import_micro_machine_spec.rb
+++ b/spec/models/import_micro_machine_spec.rb
@@ -12,6 +12,7 @@ describe ImportMicroMachine do
         finished
         syncing
         synced
+        errors
       ]
     end
   end


### PR DESCRIPTION
When a sync gets a PG error, there's no way that running the sync again is going to succeed the second or _nth_ time. This PR revises the REVERT state to a FAILED state (lolz). The expected behavior is that the PG errors will be returned by `DataWarehouse::Result`, but instead of `REVERT` moving the sync back to `FINISHED`, it moves it to `ERRORS`. The message to slack is then dispatched and the failed sync will not be picked up again until a dev investigates and changes the state.

Fixes #216