### PR TITLE
Add temp task to migrate tags to types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
+    - 'lib/tasks/temporary/*.rake'
 
 Metrics/AbcSize:
   Exclude:

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-  has_many :organization_tags
+  has_many :organization_tags, dependent: :destroy
   has_many :organizations, through: :organization_tags
   validates :name, presence: true
 end

--- a/lib/tasks/temporary/tag_type_data_migration.rake
+++ b/lib/tasks/temporary/tag_type_data_migration.rake
@@ -1,0 +1,46 @@
+desc 'Convert certain tags to types'
+task tag_type_data_migration: :environment do
+  mapping = {
+    "antique shop" => "antique shop",
+    "artist estates / foundations" => "artist estates / foundations",
+    "artist studios" => "artist studios",
+    "artist" => "artist",
+    "auction house" => "auction houses",
+    "biennials / triennials" => "biennials / triennials",
+    "charity / ngo" => nil,
+    "corporate collection" => nil,
+    "dealer" => "dealer",
+    "fair" => "fairs",
+    "gallery" => "gallery",
+    "government organization" => nil,
+    "museum" => "museum",
+    "non-art organization" => "other",
+    "performance venue" => nil,
+    "print publishers and print dealers" => "print publishers and print dealers",
+    "private collections" => "private collections",
+    "publications / publishers / archives" => "publications / publishers / archives",
+    "university museums / educational institutions" => "university museums / educational institutions",
+  }
+
+  for type_name, tag_name in mapping
+    puts ''
+    puts type_name
+    Type.transaction do
+      type = Type.create name: type_name
+      tag = Tag.find_by name: tag_name
+
+      if tag
+        for org_tag in tag.organization_tags
+          actor = org_tag.versions.first.actor
+          PaperTrail.track_changes_with(actor) do
+            org_tag.organization.organization_types.create type: type
+          end
+          print ?.
+        end
+
+        tag.organization_tags.delete_all
+        tag.delete
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a temporary rake task that migrates some tags over to types. Once this migration is complete, this task can be removed from the project. I took inspiration for this from a [thoughtbot][tb] post.

[tb]: https://robots.thoughtbot.com/data-migrations-in-rails

Note that the actor of the OrganizationTag is carried over to the OrganizationType so that we don't lose that signal. This is necessary to ensure that when we resolve the type of an organization our Rankable logic doesn't get goofed up. I note it because, technically, that RawInput record did NOT create that OrganizationType, this rake task did.

closes #228