### PR TITLE
Fix source ranking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
   def source_rank_options(type)
     options = Source.all.map do |source|
       rank = source.rank_for(type)
-      ["#{rank} - insert above #{source.name}", rank]
+      ["#{rank} - insert below #{source.name}", rank]
     end.sort
     final_rank = options.count + 1
     final_option = ["#{final_rank} - add to end", final_rank]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,10 +12,26 @@ module ApplicationHelper
     class_string
   end
 
-  def source_rank_options(type)
-    options = Source.all.map do |source|
+  def source_rank_options(type, action)
+    case action
+    when 'update'
+      edit_source_rank_options(type)
+    when 'create'
+      create_source_rank_options(type)
+    end
+  end
+
+  def edit_source_rank_options(type)
+    Source.all.map do |source|
       rank = source.rank_for(type)
       ["#{rank} - insert below #{source.name}", rank]
+    end.sort
+  end
+
+  def create_source_rank_options(type)
+    options = Source.all.map do |source|
+      rank = source.rank_for(type)
+      ["#{rank} - insert above #{source.name}", rank]
     end.sort
     final_rank = options.count + 1
     final_option = ["#{final_rank} - add to end", final_rank]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,9 +25,9 @@ module ApplicationHelper
     Source.all.map do |source|
       rank = source.rank_for(type)
       if source.name == selected_source.name
-        ["#{rank} - current value", rank]
+        ["#{rank}: current - #{source.name}", rank]
       else
-        ["#{rank} - insert below #{source.name}", rank]
+        ["#{rank}: move here - #{source.name}", rank]
       end
     end.sort
   end
@@ -35,10 +35,10 @@ module ApplicationHelper
   def create_source_rank_options(type)
     options = Source.all.map do |source|
       rank = source.rank_for(type)
-      ["#{rank} - insert above #{source.name}", rank]
+      ["#{rank}: insert above #{source.name}", rank]
     end.sort
     final_rank = options.count + 1
-    final_option = ["#{final_rank} - add to end", final_rank]
+    final_option = ["#{final_rank}: add to end", final_rank]
     options + [final_option]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
     case action
     when 'create'
       create_source_rank_options(type)
-    when 'update'
+    when 'edit'
       edit_source_rank_options(source, type)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,19 +12,23 @@ module ApplicationHelper
     class_string
   end
 
-  def source_rank_options(type, action)
+  def source_rank_options(source, type, action)
     case action
-    when 'update'
-      edit_source_rank_options(type)
     when 'create'
       create_source_rank_options(type)
+    when 'update'
+      edit_source_rank_options(source, type)
     end
   end
 
-  def edit_source_rank_options(type)
+  def edit_source_rank_options(selected_source, type)
     Source.all.map do |source|
       rank = source.rank_for(type)
-      ["#{rank} - insert below #{source.name}", rank]
+      if source.name == selected_source.name
+        ["#{rank} - current value", rank]
+      else
+        ["#{rank} - insert below #{source.name}", rank]
+      end
     end.sort
   end
 

--- a/app/views/sources/_form.html.haml
+++ b/app/views/sources/_form.html.haml
@@ -6,6 +6,6 @@
   - for type in [:email_rank, :location_rank, :organization_name_rank, :organization_type_rank, :phone_number_rank, :website_rank]
     .form-group
       = f.label type
-      = f.select(type, source_rank_options(type), {}, { class: 'form-control' })
+      = f.select(type, source_rank_options(type, action), {}, { class: 'form-control' })
 
   = f.submit button_label, { class: 'btn btn-primary' }

--- a/app/views/sources/_form.html.haml
+++ b/app/views/sources/_form.html.haml
@@ -1,7 +1,10 @@
 = form_for source do |f|
   .form-group
-    = f.label :name
     = f.text_field :name, { class: 'form-control', required: true }
+
+  <hr />
+
+  %h3 Hierarchy
 
   - for type in [:email_rank, :location_rank, :organization_name_rank, :organization_type_rank, :phone_number_rank, :website_rank]
     .form-group

--- a/app/views/sources/_form.html.haml
+++ b/app/views/sources/_form.html.haml
@@ -9,6 +9,6 @@
   - for type in [:email_rank, :location_rank, :organization_name_rank, :organization_type_rank, :phone_number_rank, :website_rank]
     .form-group
       = f.label type
-      = f.select(type, source_rank_options(type, action), {}, { class: 'form-control' })
+      = f.select(type, source_rank_options(source, type, action), {}, { class: 'form-control' })
 
   = f.submit button_label, { class: 'btn btn-primary' }

--- a/app/views/sources/edit.html.haml
+++ b/app/views/sources/edit.html.haml
@@ -1,3 +1,3 @@
 %h1 Edit Source
 
-= render partial: 'form', locals: { button_label: 'Update' }
+= render partial: 'form', locals: { button_label: 'Update', action: 'update' }

--- a/app/views/sources/edit.html.haml
+++ b/app/views/sources/edit.html.haml
@@ -1,3 +1,3 @@
 %h1 Edit Source: <em>#{source.name}</em>
 
-= render partial: 'form', locals: { button_label: 'Update', action: 'update' }
+= render partial: 'form', locals: { button_label: 'Update', action: 'edit' }

--- a/app/views/sources/edit.html.haml
+++ b/app/views/sources/edit.html.haml
@@ -1,3 +1,3 @@
-%h1 Edit Source
+%h1 Edit Source: <em>#{source.name}</em>
 
 = render partial: 'form', locals: { button_label: 'Update', action: 'update' }

--- a/app/views/sources/new.html.haml
+++ b/app/views/sources/new.html.haml
@@ -1,3 +1,3 @@
 %h1 Create Source
 
-= render partial: 'form', locals: { button_label: 'Create' }
+= render partial: 'form', locals: { button_label: 'Create', action: 'create' }

--- a/spec/features/create_source_spec.rb
+++ b/spec/features/create_source_spec.rb
@@ -10,7 +10,7 @@ feature 'Create Source' do
     scenario 'Importer creates source' do
       visit '/sources/new'
 
-      fill_in 'Name', with: 'Clearbit'
+      fill_in 'source_name', with: 'Clearbit'
 
       select '1 - add to end', from: 'Email rank'
       select '1 - add to end', from: 'Location rank'
@@ -43,7 +43,7 @@ feature 'Create Source' do
 
       visit '/sources/new'
 
-      fill_in 'Name', with: 'Clearbit'
+      fill_in 'source_name', with: 'Clearbit'
 
       select "1 - insert above #{source.name}", from: 'Email rank'
       select "1 - insert above #{source.name}", from: 'Location rank'

--- a/spec/features/create_source_spec.rb
+++ b/spec/features/create_source_spec.rb
@@ -12,12 +12,12 @@ feature 'Create Source' do
 
       fill_in 'source_name', with: 'Clearbit'
 
-      select '1 - add to end', from: 'Email rank'
-      select '1 - add to end', from: 'Location rank'
-      select '1 - add to end', from: 'Organization name rank'
-      select '1 - add to end', from: 'Organization type rank'
-      select '1 - add to end', from: 'Phone number rank'
-      select '1 - add to end', from: 'Website rank'
+      select '1: add to end', from: 'Email rank'
+      select '1: add to end', from: 'Location rank'
+      select '1: add to end', from: 'Organization name rank'
+      select '1: add to end', from: 'Organization type rank'
+      select '1: add to end', from: 'Phone number rank'
+      select '1: add to end', from: 'Website rank'
 
       click_button 'Create'
 
@@ -45,12 +45,12 @@ feature 'Create Source' do
 
       fill_in 'source_name', with: 'Clearbit'
 
-      select "1 - insert above #{source.name}", from: 'Email rank'
-      select "1 - insert above #{source.name}", from: 'Location rank'
-      select "1 - insert above #{source.name}", from: 'Organization name rank'
-      select "1 - insert above #{source.name}", from: 'Organization type rank'
-      select "1 - insert above #{source.name}", from: 'Phone number rank'
-      select "1 - insert above #{source.name}", from: 'Website rank'
+      select "1: insert above #{source.name}", from: 'Email rank'
+      select "1: insert above #{source.name}", from: 'Location rank'
+      select "1: insert above #{source.name}", from: 'Organization name rank'
+      select "1: insert above #{source.name}", from: 'Organization type rank'
+      select "1: insert above #{source.name}", from: 'Phone number rank'
+      select "1: insert above #{source.name}", from: 'Website rank'
 
       click_button 'Create'
 

--- a/spec/features/edit_sources_spec.rb
+++ b/spec/features/edit_sources_spec.rb
@@ -45,7 +45,7 @@ feature 'Edit Source' do
 
       visit "/sources/#{source_a.id}/edit"
 
-      expect(page).to_not have_content '2 - add to end'
+      expect(page).to_not have_content 'add to end'
     end
 
     scenario 'Admins can rank a source to last' do
@@ -91,7 +91,7 @@ feature 'Edit Source' do
 
       fill_in 'source_name', with: 'New Name'
 
-      last_option = "3 - insert below #{source_c.name}"
+      last_option = "3: move here - #{source_c.name}"
 
       select last_option, from: 'Email rank'
       select last_option, from: 'Location rank'

--- a/spec/features/edit_sources_spec.rb
+++ b/spec/features/edit_sources_spec.rb
@@ -89,7 +89,7 @@ feature 'Edit Source' do
 
       visit "/sources/#{source_a.id}/edit"
 
-      fill_in 'Name', with: 'New Name'
+      fill_in 'source_name', with: 'New Name'
 
       last_option = "3 - insert below #{source_c.name}"
 

--- a/spec/features/edit_sources_spec.rb
+++ b/spec/features/edit_sources_spec.rb
@@ -24,6 +24,30 @@ feature 'Edit Source' do
       expect(page).to have_css 'a.edit'
     end
 
+    scenario 'the options do not include "Add to end"' do
+      allow_any_instance_of(ApplicationController)
+        .to receive(:user).and_return(
+          {
+            uid: 'foo',
+            roles: %w[admin foo]
+          }
+        )
+
+      source_a = Fabricate(
+        :source,
+        email_rank: 1,
+        location_rank: 1,
+        organization_name_rank: 1,
+        organization_type_rank: 1,
+        phone_number_rank: 1,
+        website_rank: 1
+      )
+
+      visit "/sources/#{source_a.id}/edit"
+
+      expect(page).to_not have_content '2 - add to end'
+    end
+
     scenario 'Admins can rank a source to last' do
       allow_any_instance_of(ApplicationController)
         .to receive(:user).and_return(

--- a/spec/features/edit_sources_spec.rb
+++ b/spec/features/edit_sources_spec.rb
@@ -23,18 +23,8 @@ feature 'Edit Source' do
       visit '/sources'
       expect(page).to have_css 'a.edit'
     end
-  end
 
-  context 'with a non-admin' do
-    let(:is_admin) { false }
-
-    scenario 'Non-admins do not have access to create a new source' do
-      Fabricate(:source)
-      visit '/sources'
-      expect(page).to_not have_css 'a.edit'
-    end
-
-    scenario 'Importer edits source' do
+    scenario 'Admins can rank a source to last' do
       allow_any_instance_of(ApplicationController)
         .to receive(:user).and_return(
           {
@@ -53,7 +43,7 @@ feature 'Edit Source' do
         website_rank: 1
       )
 
-      source_b = Fabricate(
+      Fabricate(
         :source,
         email_rank: 2,
         location_rank: 2,
@@ -63,28 +53,48 @@ feature 'Edit Source' do
         website_rank: 2
       )
 
-      visit "/sources/#{source_b.id}/edit"
+      source_c = Fabricate(
+        :source,
+        email_rank: 3,
+        location_rank: 3,
+        organization_name_rank: 3,
+        organization_type_rank: 3,
+        phone_number_rank: 3,
+        website_rank: 3
+      )
+
+      visit "/sources/#{source_a.id}/edit"
 
       fill_in 'Name', with: 'New Name'
 
-      first_option = "1 - insert above #{source_a.name}"
+      last_option = "3 - insert below #{source_c.name}"
 
-      select first_option, from: 'Email rank'
-      select first_option, from: 'Location rank'
-      select first_option, from: 'Organization name rank'
-      select first_option, from: 'Organization type rank'
-      select first_option, from: 'Phone number rank'
-      select first_option, from: 'Website rank'
+      select last_option, from: 'Email rank'
+      select last_option, from: 'Location rank'
+      select last_option, from: 'Organization name rank'
+      select last_option, from: 'Organization type rank'
+      select last_option, from: 'Phone number rank'
+      select last_option, from: 'Website rank'
 
       click_button 'Update'
 
-      expect(source_b.reload.name).to eq 'New Name'
-      expect(source_b.email_rank).to eq 1
-      expect(source_b.location_rank).to eq 1
-      expect(source_b.organization_name_rank).to eq 1
-      expect(source_b.organization_type_rank).to eq 1
-      expect(source_b.phone_number_rank).to eq 1
-      expect(source_b.website_rank).to eq 1
+      expect(source_a.reload.name).to eq 'New Name'
+      expect(source_a.email_rank).to eq 3
+      expect(source_a.location_rank).to eq 3
+      expect(source_a.organization_name_rank).to eq 3
+      expect(source_a.organization_type_rank).to eq 3
+      expect(source_a.phone_number_rank).to eq 3
+      expect(source_a.website_rank).to eq 3
+    end
+  end
+
+  context 'with a non-admin' do
+    let(:is_admin) { false }
+
+    scenario 'Non-admins do not have access to create a new source' do
+      Fabricate(:source)
+      visit '/sources'
+      expect(page).to_not have_css 'a.edit'
     end
   end
 end

--- a/spec/models/source_resolver_spec.rb
+++ b/spec/models/source_resolver_spec.rb
@@ -113,5 +113,29 @@ describe SourceResolver do
         expect(source_c.reload.email_rank).to eq 3
       end
     end
+
+    context 'demoting a top source and then promoting it back' do
+      it 'orders and reorders the sources correctly' do
+        source_a = Fabricate :source, email_rank: 1
+        source_b = Fabricate :source, email_rank: 2
+        source_c = Fabricate :source, email_rank: 3
+
+        source_a.email_rank = 3
+
+        SourceResolver.resolve source_a
+
+        expect(source_b.reload.email_rank).to eq 1
+        expect(source_c.reload.email_rank).to eq 2
+        expect(source_a.reload.email_rank).to eq 3
+
+        source_a.email_rank = 1
+
+        SourceResolver.resolve source_a
+
+        expect(source_a.reload.email_rank).to eq 1
+        expect(source_b.reload.email_rank).to eq 2
+        expect(source_c.reload.email_rank).to eq 3
+      end
+    end
   end
 end


### PR DESCRIPTION
In the UI, ranking a source last corrupts the hierarchy. Given sources such as `[1, 2, 3]`, moving `1` to `3` results in `[2, 3, 3]`. After reviewing the `source_resolver` and not succeeding in reproducing the bug in tests, I determined the bug was probably in the UI. A failing test confirmed this. 

@jonallured and I decided to change a couple things to in the UI to make things more clear. This PR addresses those revisions, among others.

- [x] Revise language on select options. Currently they say "1 - insert above Foo Source." I'll change this to say "1 - insert below Foo Source." 
- [x] Revise language on selected option to say "2 - Selected rank."
- [x] Add horizontal rule between the name and rank fields to show those are different actions.
- [x] Add the name of the source being edited to the H1.
- [x] Only show "Add to end" option when a new source is being created.
- [ ] On production, restore the source ranks to a correct state.