### PR TITLE
Fix sort method for source select options

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,28 +15,32 @@ module ApplicationHelper
   def source_rank_options(source, type, action)
     case action
     when 'create'
-      create_source_rank_options(type)
+      options = create_source_rank_options(type)
     when 'edit'
-      edit_source_rank_options(source, type)
+      options = edit_source_rank_options(source, type)
     end
+
+    options.sort_by(&:last)
   end
 
   def edit_source_rank_options(selected_source, type)
     Source.all.map do |source|
       rank = source.rank_for(type)
+
       if source.name == selected_source.name
         ["#{rank}: current - #{source.name}", rank]
       else
         ["#{rank}: move here - #{source.name}", rank]
       end
-    end.sort
+    end
   end
 
   def create_source_rank_options(type)
     options = Source.all.map do |source|
       rank = source.rank_for(type)
       ["#{rank}: insert above #{source.name}", rank]
-    end.sort
+    end
+
     final_rank = options.count + 1
     final_option = ["#{final_rank}: add to end", final_rank]
     options + [final_option]


### PR DESCRIPTION
With select options greater than 10 lists appeared thusly `1, 10,  2, 3, ...`. We were calling `sort` on a string value `['10 - Foo Source', 10]`. This PR refactors to sort on the last element of the array, which is an integer.