### PR TITLE
Source rank migration

### DIFF
--- a/lib/tasks/temporary/in_business_data_migration.rake
+++ b/lib/tasks/temporary/in_business_data_migration.rake
@@ -1,17 +1,19 @@
-desc 'Convert in_business to a string'
-task in_business_data_migration: :environment do
-  PaperTrail.track_changes_with('data migration') do
-    Organization.where(in_business: 'false').update_all(in_business: Organization::CLOSED)
-    Organization.where(in_business: 'true').update_all(in_business: Organization::UNKNOWN)
+namespace :temporary do
+  desc 'Convert in_business to a string'
+  task in_business_data_migration: :environment do
+    PaperTrail.track_changes_with('data migration') do
+      Organization.where(in_business: 'false').update_all(in_business: Organization::CLOSED)
+      Organization.where(in_business: 'true').update_all(in_business: Organization::UNKNOWN)
 
-    source = Source.find_by name: 'HumanOutsourcer'
-    raw_inputs = source.imports.flat_map(&:raw_inputs)
+      source = Source.find_by name: 'HumanOutsourcer'
+      raw_inputs = source.imports.flat_map(&:raw_inputs)
 
-    in_business_raw_inputs = raw_inputs.select do |raw_input|
-      raw_input.output_id && !raw_input.data['in_business'].nil?
+      in_business_raw_inputs = raw_inputs.select do |raw_input|
+        raw_input.output_id && !raw_input.data['in_business'].nil?
+      end
+
+      organization_ids = in_business_raw_inputs.map(&:output_id)
+      Organization.where.not(in_business: Organization::CLOSED).where(id: organization_ids).update_all(in_business: Organization::OPEN)
     end
-
-    organization_ids = in_business_raw_inputs.map(&:output_id)
-    Organization.where.not(in_business: Organization::CLOSED).where(id: organization_ids).update_all(in_business: Organization::OPEN)
   end
 end

--- a/lib/tasks/temporary/reorder_sources_migration.rake
+++ b/lib/tasks/temporary/reorder_sources_migration.rake
@@ -1,14 +1,16 @@
-desc 'For each rank, reorder the sources'
-task reorder_sources_migration: :environment do
-  source_ranks = Source.column_names.keep_if {|name| name.end_with?('_rank') }
+namespace :temporary do
+  desc 'For each rank, reorder the sources'
+  task reorder_sources_migration: :environment do
+    source_ranks = Source.column_names.keep_if {|name| name.end_with?('_rank') }
 
-  source_ranks.each do |rank_name|
-    counter = 0
-    rank_column_name = rank_name.to_sym
-    sources = Source.pluck(rank_column_name, :id, :name).sort
+    source_ranks.each do |rank_name|
+      counter = 0
+      rank_column_name = rank_name.to_sym
+      sources = Source.pluck(rank_column_name, :id, :name).sort
 
-    sources.each do |source|
-      Source.find(source[1]).update_attribute(rank_column_name, counter += 1)
+      sources.each do |source|
+        Source.find(source[1]).update_attribute(rank_column_name, counter += 1)
+      end
     end
   end
 end

--- a/lib/tasks/temporary/reorder_sources_migration.rake
+++ b/lib/tasks/temporary/reorder_sources_migration.rake
@@ -1,0 +1,14 @@
+desc 'For each rank, reorder the sources'
+task reorder_sources_migration: :environment do
+  source_ranks = Source.column_names.keep_if {|name| name.end_with?('_rank') }
+
+  source_ranks.each do |rank_name|
+    counter = 0
+    rank_column_name = rank_name.to_sym
+    sources = Source.pluck(rank_column_name, :id, :name).sort
+
+    sources.each do |source|
+      Source.find(source[1]).update_attribute(rank_column_name, counter += 1)
+    end
+  end
+end

--- a/lib/tasks/temporary/tag_type_data_migration.rake
+++ b/lib/tasks/temporary/tag_type_data_migration.rake
@@ -1,46 +1,48 @@
-desc 'Convert certain tags to types'
-task tag_type_data_migration: :environment do
-  mapping = {
-    "antique shop" => "antique shop",
-    "artist estates / foundations" => "artist estates / foundations",
-    "artist studios" => "artist studios",
-    "artist" => "artist",
-    "auction house" => "auction houses",
-    "biennials / triennials" => "biennials / triennials",
-    "charity / ngo" => nil,
-    "corporate collection" => nil,
-    "dealer" => "dealer",
-    "fair" => "fairs",
-    "gallery" => "gallery",
-    "government organization" => nil,
-    "museum" => "museum",
-    "non-art organization" => "other",
-    "performance venue" => nil,
-    "print publishers and print dealers" => "print publishers and print dealers",
-    "private collections" => "private collections",
-    "publications / publishers / archives" => "publications / publishers / archives",
-    "university museums / educational institutions" => "university museums / educational institutions",
-  }
+namespace :temporary do
+  desc 'Convert certain tags to types'
+  task tag_type_data_migration: :environment do
+    mapping = {
+      "antique shop" => "antique shop",
+      "artist estates / foundations" => "artist estates / foundations",
+      "artist studios" => "artist studios",
+      "artist" => "artist",
+      "auction house" => "auction houses",
+      "biennials / triennials" => "biennials / triennials",
+      "charity / ngo" => nil,
+      "corporate collection" => nil,
+      "dealer" => "dealer",
+      "fair" => "fairs",
+      "gallery" => "gallery",
+      "government organization" => nil,
+      "museum" => "museum",
+      "non-art organization" => "other",
+      "performance venue" => nil,
+      "print publishers and print dealers" => "print publishers and print dealers",
+      "private collections" => "private collections",
+      "publications / publishers / archives" => "publications / publishers / archives",
+      "university museums / educational institutions" => "university museums / educational institutions",
+    }
 
-  for type_name, tag_name in mapping
-    next if Type.find_by name: type_name
-    puts ''
-    puts type_name
-    Type.transaction do
-      type = Type.create name: type_name
-      tag = Tag.find_by name: tag_name
+    for type_name, tag_name in mapping
+      next if Type.find_by name: type_name
+      puts ''
+      puts type_name
+      Type.transaction do
+        type = Type.create name: type_name
+        tag = Tag.find_by name: tag_name
 
-      if tag
-        for org_tag in tag.organization_tags
-          actor = org_tag.versions.first.actor
-          PaperTrail.track_changes_with(actor) do
-            org_tag.organization.organization_types.create type: type
+        if tag
+          for org_tag in tag.organization_tags
+            actor = org_tag.versions.first.actor
+            PaperTrail.track_changes_with(actor) do
+              org_tag.organization.organization_types.create type: type
+            end
+            print ?.
           end
-          print ?.
-        end
 
-        tag.organization_tags.delete_all
-        tag.delete
+          tag.organization_tags.delete_all
+          tag.delete
+        end
       end
     end
   end


### PR DESCRIPTION
Reorders the ranks hierarchy. In data we have corrupted rank hierarchies, such as `[1,2,3,4,5,7,8,9,10,11,12,13,13]`. 

This migration will renumber ranks with a new hierarchy.  In the case above, starting after `5`, each item will be renumbered: `7` => `6`, `8` => `9`. 

Notice there is a tie in the last two items, `13` and `13`. How do we know which one comes first? Luckily it doesn't matter. If the rank is lower than one, then the source won't be selected for export, so we can safely ignore this detail.

To see the migration it's more clean [here](https://github.com/artsy/bearden/pull/256/commits/15417ff474dff5514618aea84de9863092d543b9). The other commit adds a namespace for other rake tasks.