### PR TITLE
Bump location redshift field to 1024 chars

### DIFF
--- a/lib/tasks/redshift.rake
+++ b/lib/tasks/redshift.rake
@@ -29,7 +29,7 @@ namespace :redshift do
           in_business character varying, \
           latitude double precision, \
           longitude double precision, \
-          location character varying, \
+          location varchar(1024), \
           organization_name character varying, \
           organization_type character varying, \
           phone_number character varying, \


### PR DESCRIPTION
Syncs were failing because Arabic characters were getting counted as bytes, which quickly exceeded the former limit of 256.