### PR TITLE
Misc maintainance

### DIFF
--- a/app/jobs/start_sync_job.rb
+++ b/app/jobs/start_sync_job.rb
@@ -35,7 +35,7 @@ class StartSyncJob < ApplicationJob
       imports_to_sync -= 1
     end
 
-    return imports_to_sync > 0
+    imports_to_sync.positive?
   end
 
   def start_sync

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -38,6 +38,10 @@ class Import < ApplicationRecord
     machine.trigger ImportMicroMachine::INSYNC
   end
 
+  def should_sync?
+    raw_inputs.where.not(exception: nil).count != raw_inputs.count
+  end
+
   def fail
     machine.trigger ImportMicroMachine::FAIL
   end

--- a/app/models/organization_type.rb
+++ b/app/models/organization_type.rb
@@ -8,7 +8,7 @@ class OrganizationType < ApplicationRecord
   delegate :name, to: :type
 
   def content=(value)
-    type = Type.find_by name: value
+    type = Type.find_by name: value.downcase
     self.type = type
   end
 end

--- a/lib/tasks/report_duplicate_organizations.rake
+++ b/lib/tasks/report_duplicate_organizations.rake
@@ -1,5 +1,5 @@
 namespace :report do
-  desc 'Prints a count and list of websites with possible duplicate organizations'
+  desc 'Print a count and list of domains with possible duplicate organizations'
   task duplicate_organizations: :environment do
     domains = Website.pluck(:content, :organization_id).group_by do |item|
       content, _id = item

--- a/lib/tasks/report_duplicate_organizations.rake
+++ b/lib/tasks/report_duplicate_organizations.rake
@@ -1,0 +1,17 @@
+namespace :report do
+  desc 'Prints a count and list of websites with possible duplicate organizations'
+  task duplicate_organizations: :environment do
+    domains = Website.pluck(:content, :organization_id).group_by do |item|
+      content, _id = item
+      content.split('/')[2]
+    end
+
+    duplicates = domains.select do |_website, grouped_results|
+      next false unless grouped_results.size > 1
+      grouped_results.map(&:last).uniq.size > 1
+    end
+
+    puts "Count: #{duplicates.values.map(&:last).flatten.uniq.count}"
+    puts duplicates
+  end
+end

--- a/spec/models/organization_builder_spec.rb
+++ b/spec/models/organization_builder_spec.rb
@@ -19,7 +19,7 @@ describe OrganizationBuilder do
     end
 
     context 'with a matching website after resolution' do
-      it 'creates a website for the redirect and finds the organization' do
+      xit 'creates a website for the redirect and finds the organization' do
         organization = Fabricate :organization
         website = Fabricate(
           :website,

--- a/spec/models/organization_builder_spec.rb
+++ b/spec/models/organization_builder_spec.rb
@@ -24,12 +24,12 @@ describe OrganizationBuilder do
         website = Fabricate(
           :website,
           organization: organization,
-          content: 'https://www.artsy.net/'
+          content: 'https://www.artsy.net'
         )
 
         results = [
           { status: 301, content: 'http://artsy.net' },
-          { status: 200, content: website.content }
+          { status: 200, content: "#{website.content}/" }
         ]
 
         resolver = double(


### PR DESCRIPTION
Several small changes to address issues that arose during the last import, namely:

- Don't trigger a sync if all of the imported CSVs contain 100% errors
- Allow mixed-case strings in CSV tag names
- Add a failing (but skipped test) for a known bug which is creating duplicates (see #258)
- Add a new rake task `rake report:duplicate_organizations` to print out a count and a list of duplicate organizations