### PR TITLE
Fail CI builds when migration errors

### DIFF
--- a/script/heroku_deploy
+++ b/script/heroku_deploy
@@ -6,5 +6,5 @@ git remote add heroku git@heroku.com:$APP_NAME.git
 git fetch heroku
 heroku pg:backups:capture
 git push --force heroku $CIRCLE_SHA1:master
-heroku run rake db:migrate
+heroku run --exit-code rake db:migrate
 heroku restart


### PR DESCRIPTION
This is something I picked up from @ashkan18 on Impulse. When you pass the `exit-code` flag and there are errors in migrations then the build will fail rather than silently failing. Seems like a best practice for any of our apps that use Heroku and Postgres.