### PR TITLE
Fix deployment config for Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,15 @@ jobs:
 
       - run: bundle exec rake
 
+      - run: bash .circleci/heroku_setup
+      - add_ssh_keys:
+          fingerprints:
+            - "85:44:31:07:7a:a0:4e:bb:50:91:f0:d8:23:8f:69:03"
       - deploy:
           name: Deploy
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./script/heroku_deploy bearden-staging
+              .circleci/heroku_deploy bearden-staging
             elif [ "${CIRCLE_BRANCH}" == "release" ]; then
-              ./script/heroku_deploy bearden-production
+              .circleci/heroku_deploy bearden-production
             fi

--- a/.circleci/heroku_deploy
+++ b/.circleci/heroku_deploy
@@ -2,8 +2,6 @@
 
 APP_NAME=$1
 
-git remote add heroku git@heroku.com:$APP_NAME.git
-git fetch heroku
 heroku pg:backups:capture
 git push --force heroku $CIRCLE_SHA1:master
 heroku run --exit-code rake db:migrate

--- a/.circleci/heroku_setup
+++ b/.circleci/heroku_setup
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+git remote add heroku https://git.heroku.com/$APP_NAME.git
+wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
+mkdir -p /usr/local/lib /usr/local/bin
+tar -xvzf heroku-linux-amd64.tar.gz -C /usr/local/lib
+ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
+
+cat > ~/.netrc << EOF
+machine api.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+machine git.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+EOF
+
+# Add heroku.com to the list of known hosts
+ssh-keyscan -H heroku.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
This was done following this walkthrough:

https://circleci.com/docs/2.0/project-walkthrough/#deploying-to-heroku

I ended up generating a new SSH keypair and storing those creds in 1Password for posterity.