### PR TITLE
Migrate cities for Factual imports

### DIFF
--- a/lib/tasks/temporary/factual_migration.rake
+++ b/lib/tasks/temporary/factual_migration.rake
@@ -9,12 +9,13 @@ namespace :temporary do
       raw_inputs.each do |raw_input|
         data = raw_input.data
 
-        locations = Location
-          .where(latitude: data['latitude'])
-          .where(longitude: data['longitude'])
-          
-        locations.each do |location|
-          if data['locality'].present? && location.city.nil?
+        if data['locality'].present?
+          locations = Location
+            .where(latitude: data['latitude'])
+            .where(longitude: data['longitude'])
+            .where(city: nil)
+
+          locations.each do |location|
             location.update_attribute(:city, data['locality'])
             puts "Updated Location(#{location.id}): City: #{data['locality']} from RawInput(#{raw_input.id})"
           end

--- a/lib/tasks/temporary/factual_migration.rake
+++ b/lib/tasks/temporary/factual_migration.rake
@@ -1,0 +1,25 @@
+namespace :temporary do
+  desc 'Fill in city from old Factual imports'
+  task factual_re_migration: :environment do
+    factual_imports = [27, 28, 29]
+    
+    factual_imports.each do |import_id|
+      raw_inputs = RawInput.where(import: import_id).where(exception: nil)
+
+      raw_inputs.each do |raw_input|
+        data = raw_input.data
+
+        locations = Location
+          .where(latitude: data['latitude'])
+          .where(longitude: data['longitude'])
+          
+        locations.each do |location|
+          if data['locality'].present? && location.city.nil?
+            location.update_attribute(:city, data['locality'])
+            puts "Updated Location(#{location.id}): City: #{data['locality']} from RawInput(#{raw_input.id})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/temporary/factual_migration.rake
+++ b/lib/tasks/temporary/factual_migration.rake
@@ -16,8 +16,10 @@ namespace :temporary do
             .where(city: nil)
 
           locations.each do |location|
-            location.update_attribute(:city, data['locality'])
-            puts "Updated Location(#{location.id}): City: #{data['locality']} from RawInput(#{raw_input.id})"
+            PaperTrail.track_changes_with('PR#274') do
+              location.update_attribute(:city, data['locality'])
+              puts "Updated Location(#{location.id}): City: #{data['locality']} from RawInput(#{raw_input.id})"
+            end
           end
         end
       end


### PR DESCRIPTION
The cities didn't get migrated with factual, because that field is called `locality` (versus `city`) in the CSV. This migration sorts through those raw input records and adds city fields that are blank to existing locations.

Closes https://github.com/artsy/collector-experience/issues/353
Closes https://github.com/artsy/bearden/issues/263