### PR TITLE
Add field for Locations.geocode_response

### DIFF
--- a/app/jobs/geocode_location_job.rb
+++ b/app/jobs/geocode_location_job.rb
@@ -1,10 +1,9 @@
 class GeocodeLocationJob < ApplicationJob
-  class NoResultsFound < StandardError; end
-
-  JOB_DELAY = 0.2.seconds
   FALLBACK_COORDINATES = [0.0, 0.0].freeze
   FALLBACK_COUNTRY = nil
   FALLBACK_CITY = nil
+  JOB_DELAY = 0.2.seconds
+  NO_RESULTS_FOUND = 'NO_RESULTS_FOUND'.freeze
 
   def perform
     location = next_location
@@ -42,7 +41,7 @@ class GeocodeLocationJob < ApplicationJob
       longitude: FALLBACK_COORDINATES[1],
       country: FALLBACK_COUNTRY,
       city: FALLBACK_CITY,
-      geocode_response: NoResultsFound.to_s
+      geocode_response: NO_RESULTS_FOUND
     }
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,12 +7,4 @@ class Location < ApplicationRecord
 
   include Rankable
   include Auditable
-
-  def geocoded?
-    latitude.present? && longitude.present?
-  end
-
-  def geocodable?
-    content? && !geocoded?
-  end
 end

--- a/db/migrate/20170630163954_add_geocode_response_to_location.rb
+++ b/db/migrate/20170630163954_add_geocode_response_to_location.rb
@@ -1,0 +1,9 @@
+class AddGeocodeResponseToLocation < ActiveRecord::Migration[5.1]
+  def up
+    add_column :locations, :geocode_response, :json
+  end
+
+  def down
+    remove_column :locations, :geocode_response
+  end
+end

--- a/spec/jobs/geocode_location_job_spec.rb
+++ b/spec/jobs/geocode_location_job_spec.rb
@@ -87,7 +87,7 @@ describe GeocodeLocationJob do
       expect(org.locations.first.country).to eq nil
       expect(org.locations.first.city).to eq nil
 
-      error = 'GeocodeLocationJob::NoResultsFound'
+      error = GeocodeLocationJob::NO_RESULTS_FOUND
       expect(org.locations.first.geocode_response).to eq error
     end
 

--- a/spec/jobs/geocode_location_job_spec.rb
+++ b/spec/jobs/geocode_location_job_spec.rb
@@ -9,32 +9,6 @@ describe GeocodeLocationJob do
       allow(Geocoder).to receive(:search)
     end
 
-    it 'moves on to geocode the next location when geocodable? is false' do
-      result = double(
-        :result,
-        city: 'Berlin',
-        country: 'Germany',
-        coordinates: [52.5200066, 13.404954]
-      )
-      allow(Geocoder).to receive(:search).and_return([result])
-
-      org = Fabricate :organization
-      org.locations.create(
-        content: 'New York City', latitude: 1234, longitude: 5678
-      )
-      org.locations.create content: '401 Broadway, New York City'
-
-      perform_enqueued_jobs do
-        GeocodeLocationJob.perform_later
-        assert_performed_jobs 2
-      end
-
-      expect(org.locations.last.latitude).to eql result.coordinates[0]
-      expect(org.locations.last.longitude).to eql result.coordinates[1]
-      expect(org.locations.last.country).to eql result.country
-      expect(org.locations.last.city).to eql result.city
-    end
-
     it 'stops raises an error when OverQueryLimitError is raised' do
       expect(Geocoder).to receive(:search)
         .and_raise(Geocoder::OverQueryLimitError)

--- a/spec/jobs/geocode_location_job_spec.rb
+++ b/spec/jobs/geocode_location_job_spec.rb
@@ -9,12 +9,13 @@ describe GeocodeLocationJob do
       allow(Geocoder).to receive(:search)
     end
 
-    it 'stops raises an error when OverQueryLimitError is raised' do
+    it 'raises an error when OverQueryLimitError is raised' do
       expect(Geocoder).to receive(:search)
         .and_raise(Geocoder::OverQueryLimitError)
       org = Fabricate :organization
       org.locations.create(
-        content: 'New York City', latitude: 1234, longitude: nil
+        content: 'New York City',
+        geocode_response: nil
       )
 
       perform_enqueued_jobs do
@@ -26,8 +27,14 @@ describe GeocodeLocationJob do
 
     it 'enqueues one job after another, after another, after another...' do
       org = Fabricate :organization
-      org.locations.create content: 'Berlin, Germany'
-      org.locations.create content: '401 Broadway, New York City'
+      org.locations.create(
+        content: 'Berlin, Germany',
+        geocode_response: nil
+      )
+      org.locations.create(
+        content: '401 Broadway, New York City',
+        geocode_response: nil
+      )
 
       perform_enqueued_jobs do
         GeocodeLocationJob.perform_later
@@ -39,7 +46,7 @@ describe GeocodeLocationJob do
       org = Fabricate :organization
       org.locations.create content: 'Berlin, Germany'
       org.locations.create(
-        content: 'New York City', latitude: 1234, longitude: 5678
+        content: 'New York City', geocode_response: { foo: 'bar' }.to_json
       )
 
       perform_enqueued_jobs do
@@ -50,9 +57,9 @@ describe GeocodeLocationJob do
 
     it 'only does jobs for non-geocoded Locations' do
       org = Fabricate :organization
-      org.locations.create content: 'Berlin, Germany'
+      org.locations.create content: 'Berlin, Germany', geocode_response: nil
       org.locations.create(
-        content: 'New York City', latitude: 1234, longitude: 5678
+        content: 'New York City', geocode_response: { foo: 'bar' }.to_json
       )
 
       perform_enqueued_jobs do
@@ -66,31 +73,34 @@ describe GeocodeLocationJob do
       fallback_coordinates = GeocodeLocationJob::FALLBACK_COORDINATES
 
       allow(Geocoder).to receive(:search)
-        .and_return(nil)
+        .and_return([])
 
       org = Fabricate :organization
-      org.locations.create content: 'Nil Town, USA'
+      org.locations.create content: 'Nil Town, USA', geocode_response: nil
 
       perform_enqueued_jobs do
         GeocodeLocationJob.perform_later
       end
 
-      expect(org.locations.first.latitude).to eql fallback_coordinates[0]
-      expect(org.locations.first.longitude).to eql fallback_coordinates[1]
-      expect(org.locations.first.country).to eql nil
-      expect(org.locations.first.city).to eql nil
+      expect(org.locations.first.latitude).to eq fallback_coordinates[0]
+      expect(org.locations.first.longitude).to eq fallback_coordinates[1]
+      expect(org.locations.first.country).to eq nil
+      expect(org.locations.first.city).to eq nil
+
+      error = 'GeocodeLocationJob::NoResultsFound'
+      expect(org.locations.first.geocode_response).to eq error
     end
 
     it 'records an Import and Source for all records' do
       organization = Fabricate :organization
-      Fabricate :location, latitude: nil, organization: organization
-      Fabricate :location, latitude: nil, organization: organization
+      Fabricate :location, geocode_response: nil, organization: organization
+      Fabricate :location, geocode_response: nil, organization: organization
 
       perform_enqueued_jobs do
         GeocodeLocationJob.perform_later
 
         assert_performed_jobs 3
-        expect(Location.count).to eql 2
+        expect(Location.count).to eq 2
 
         Location.all.each do |location|
           actor = location.versions.last.actor


### PR DESCRIPTION
This PR follows up on https://github.com/artsy/bearden/pull/274, because, as @madeleineb pointed out, around ~38k records on Redshift still seem to be not geocoded. 

Looking deeper into the data, there are a lot of records that are marked as geocoded (they have non-nil latitudes and longitudes), but do not have meaningful data (nil city and country fields).

Unfortunately, checking for non-nil latitudes and longitudes does not return an accurate picture of whether or not a location has been geocoded. This is because, for imports, we allow users to include `latitude` and `longitude` fields. That means locations can have blank city or country fields and never be found by the geocoder. 

Other things might also be at play here. More below on that.

### TL;DR

My solution is to add more visibility into geocoder by saving the response in a new field, `Locations.geocode_response`. This will allow us to return to some of these locations for better analysis after geocoder has been running. 

What does that mean for current locations? It does mean that zero of the 150,518 locations will be marked as geocoded. Geocoder will run daily, as it does now, making requests every `0.2.seconds`. 

From the perspective of Looker/Redshift, not much will change. When new data is synced, there will simply be more accurate location records. There will be no loss of data.

### More background:

This query selects all the locations that we humans consider to be not geocoded. There are 70,794 such locations.

```sql
 select id, latitude, longitude, city, country, left(content, 15) from locations where latitude = 0 or longitude = 0 or city is null or country is null;
```

There are no locations such that latitude or longitude are null. This means that, according to the (flawed) geocoder, all locations have been geocoded. 

So why do some results seem to be not geocoded? Here are some examples from looking at the data.

- `Location.find(77)` is a location that has fallback lat and long (`[0,0]`). This suggests the geocode results returned nil. Yet `geoTest(77)` shows that city and country should be `["Innsbruck", "Austria”]`. It's uncertain why this is happening. The bright side is that locations such as this should be fixed by running the geocoder on them again.
- `Location.find(4700)` shows a location with `content: "US, Washington”`. After geocoding, this resolves to `country: United States and city: nil`. This looks like a missing city, but it's accurate. I saw many locations like this one.
- `Location.find(4418)` is a location with `content: “JP, Tokyo”`. It is geocoded with `country: “Japan”, city: nil`. It looks like an error, and yet these are the results given by geocoder. 
- Another thing to consider is that `rankable` selects the top location based on what a human thinks is the best bulk source of data, not the best actual location. This could result in some amount of errors. Probably not the bulk of them though.

```ruby
# Test geocode results for a location
def geoTest(id)
  r = Geocoder.search(Location.find(id).content).first
  [r.city, r.country]
end
```