### PR TITLE
@jonallured: fix charlock_holmes gem setup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       carrierwave
       fog
       uuidtools
-    charlock_holmes (0.7.3)
+    charlock_holmes (0.7.5)
     choice (0.2.0)
     coderay (1.1.1)
     coffee-rails (4.2.2)

--- a/bin/setup
+++ b/bin/setup
@@ -44,7 +44,9 @@ if ! command -v copy_env > /dev/null; then
 fi
 
 # STEP 2
-printf "${CLEAR_LINE}[2/${STEPS}]  installing gems"
+printf "${CLEAR_LINE}[2/${STEPS}]  installing gems and their dependencies"
+brew install icu4c
+bundle config build.charlock_holmes --with-icu-dir=/usr/local/opt/icu4c
 bundle install > /dev/null
 
 # STEP 3


### PR DESCRIPTION
The gem `charlock_holmes` depends on ICU, and [it recommends](https://github.com/brianmario/charlock_holmes#homebrew) installing that via homebrew. You then have to point bundler to the correct directory as its a keg-only install. Lastly, the old release (0.7.3) doesn't seem to compile with the latest ICU, so I updated it and now `bundle install` works fine. 