### PR TITLE
@jonallured: fix elasticsearch reindex task

### DIFF
--- a/app/jobs/search_delete_job.rb
+++ b/app/jobs/search_delete_job.rb
@@ -1,4 +1,6 @@
-class SearchDeleteJob < ApplicationJob
+class SearchDeleteJob
+  include Sidekiq::Worker
+
   def perform(klass, id)
     obj = klass.constantize.find(id)
     return unless obj

--- a/app/jobs/search_index_job.rb
+++ b/app/jobs/search_index_job.rb
@@ -1,4 +1,6 @@
-class SearchIndexJob < ApplicationJob
+class SearchIndexJob
+  include Sidekiq::Worker
+
   def perform(klass, id)
     obj = klass.constantize.find(id)
     return unless obj

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -17,10 +17,10 @@ module Searchable
   end
 
   def delay_es_index
-    SearchIndexJob.new.perform(self.class.name, id)
+    SearchIndexJob.perform_async(self.class.name, id)
   end
 
   def delay_es_delete
-    SearchDeleteJob.new.perform(self.class.name, id)
+    SearchDeleteJob.perform_async(self.class.name, id)
   end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,9 +1,9 @@
 namespace :elasticsearch do
   desc 'reindex all orgs in search'
-  task :reindex do
+  task reindex: :environment do
     Organization.pluck(:id).each_slice(1000) do |ids|
       args = ids.map { |id| ['Organization', id] }
-      Sidekiq::Client.push_bulk('class' => SearchIndexWorker, 'args' => args)
+      Sidekiq::Client.push_bulk('class' => SearchIndexJob, 'args' => args)
       puts "[#{Time.now.utc}] Queued #{ids.size} ids."
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'webmock/rspec'
+require 'sidekiq/testing'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -13,3 +14,4 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow: 'localhost')
+Sidekiq::Testing.inline!


### PR DESCRIPTION
Thanks for looking into the migration issues with the `elasticsearch:reindex` task. I made the two fixes you suggested and switched the workers away from `ActiveJob` to just use the `Sidekiq::Worker` module as we do in our other projects. The migration was working locally with this new setup.

ActiveJob doesn't support bulk pushing, as confirmed by Mike Perham [here](https://codexample.org/questions/721381/bulk-insert-using-activejob-and-sidekiq.c). We do want that ability in this context as it's more efficient when iterating over all the Organizations - it reduces Redis round-trip latency. 

Fixes https://github.com/artsy/bearden/issues/296.