### PR TITLE
@jonallured: fix elasticsearch environments

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,7 +5,7 @@ module Searchable
   include Estella::Searchable
 
   included do
-    index_name [name.downcase.pluralize, Rails.env].join('_')
+    index_name [name.downcase.pluralize, Rails.application.secrets.elasticsearch_env].join('_')
 
     # disable estella inline indexing
     skip_callback(:save, :after, :es_index)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -33,15 +33,16 @@ default: &default
   slack_api_token: <%= ENV['SLACK_API_TOKEN'] %>
   slack_channel: <%= ENV['SLACK_CHANNEL'] %>
   elasticsearch_url: <%= ENV['ELASTICSEARCH_URL'] %>
+  elasticsearch_env: <%= ENV.fetch('ELASTICSEARCH_ENV', 'staging') %>
 
 development:
   <<: *default
   secret_key_base: ed2d5d2c2b2851c5ccf859e167f2e1b1ccf477e6416f6b83cfb2fc67dc8a4a26f3d8126f338a624d8638cab0f6b29bd4dede97ce82e022abd1855539fa66067d
-
+  elasticsearch_env: development
 test:
   <<: *default
   secret_key_base: 3e3477ec045f585f0e78a381226a3de9a6deed1c9d6ecd9c2a209e7f54e8b8b5bf735839ddc88fe3790c7b967bb721e2efadeab9f5ae3729c6718a34408f5f15
-
+  elasticsearch_env: test
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:


### PR DESCRIPTION
As discussed in https://github.com/artsy/bearden/issues/300, I use a new ENV var called `ELASTICSEARCH_ENV` to deduce the index name for Organizations.

Thanks for catching that issue - it recently caught me out in Diffusion too, so I really should have foreseen it.

I've updated the config vars in Heroku staging/production.

**Migration**

We need to re-migrate now I guess, since all our staging data incorrectly went into a production index. So on staging first, and then production, we should do this:

```ruby
# this recreates the index and all its settings/mappings without reindexing the data.
Organization.reload_index! 
# exit the rails console...
bundle exec rake elasticsearch:reindex
```
 
I'm happy to do that myself once this is merged, but let me know if you'd rather do it. 

Fixes https://github.com/artsy/bearden/issues/300