### PR TITLE
@jonallured: fix graphql organization schema to use top ranked name #migration

### DIFF
--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -2,5 +2,5 @@ Types::OrganizationType = GraphQL::ObjectType.define do
   name 'Organization'
 
   field :id, !types.ID
-  field :names, !types[types.String]
+  field :name, !types.String
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,7 +20,8 @@ class Organization < ApplicationRecord
 
   searchable do
     field :id, type: 'integer'
-    field :name, using: :names, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 1.0
+    field :name, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 1.5
+    field :alternate_names, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 1.0
     field :tag, using: :tag_names, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 0.5
     field :website, using: :website_urls, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 0.5
     field :city, using: :cities, type: 'string', analysis: FULLTEXT_ANALYSIS, factor: 0.5
@@ -34,8 +35,16 @@ class Organization < ApplicationRecord
     OrganizationsQuery
   end
 
+  def name
+    names.first
+  end
+
+  def alternate_names
+    names.drop(1)
+  end
+
   def names
-    organization_names.pluck(:content)
+    organization_names.order(created_at: :desc).sort_by(&:rank).pluck(:content)
   end
 
   def tag_names

--- a/app/models/organizations_query.rb
+++ b/app/models/organizations_query.rb
@@ -11,7 +11,11 @@ class OrganizationsQuery < Estella::Query
               'name.ngram^5',
               'name.default^5',
               'name.shingle^1',
-              'name.snowball^1'
+              'name.snowball^1',
+              'alternate_names.ngram^5',
+              'alternate_names.default^5',
+              'alternate_names.shingle^1',
+              'alternate_names.snowball^1'
             ],
             query: params[:term]
           }

--- a/spec/graphql/search_spec.rb
+++ b/spec/graphql/search_spec.rb
@@ -19,6 +19,7 @@ describe GraphqlController, type: :controller do
         request.headers.merge! auth_headers
       end
       it 'runs a query' do
+        Organization.recreate_index!
         post :execute, params: { query: '{ search(term: "x") { id } }' }
         expect(response.status).to eq 200
         expect(response.body).to eq '{"data":{"search":[]}}'

--- a/spec/graphql/types/organization_type_spec.rb
+++ b/spec/graphql/types/organization_type_spec.rb
@@ -8,7 +8,7 @@ describe BeardenSchema.types['Organization'] do
   it {
     is_expected.to have_graphql_fields(
       :id,
-      :names
+      :name
     )
   }
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -97,6 +97,7 @@ describe Organization do
 
     before do
       Organization.recreate_index!
+      allow_any_instance_of(OrganizationName).to receive(:rank).and_return(1)
 
       Fabricate(
         :organization_name,


### PR DESCRIPTION
Our representation of Organization objects via the Search API currently returns an unsorted array of names - API clients should only really see the top ranked name as this is the display name they should use when referring to the organization. The clients currently have no need for the alternate names, though we can add them to the schema if need be in future.

Here I index a `name` field in Elasticsearch as the authoritative (top ranked) name for an Organization, and additionally index other names in an `alternate_names` array as is our convention in other search indices. I've adjusted the search query to search on _all_ the names, but now the API only returns the `name` attribute. 

**Migration**

We need to recreate the index as we are scrapping the `names` field and adding the `name` and `alternate_names` fields in its pace. ES doesn't support deleting existing fields in a live index so in a console we drop the old index and re-declare the mappings for the new one:

```
Organization.reload_index!
```

And then we can dispatch our indexing sidekiq workers to populate the new index:

```
bundle exec rake elasticsearch:reindex
```