### PR TITLE
@jonallured: ensure elasticsearch is up before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
         paths:
           - vendor/bundle
 
+      # Make sure that Elasticsearch is up before running tests:
+      - run: sleep 10 && curl --retry 10 --retry-delay 5 -v http://127.0.0.1:9200/
+
       - run: mv config/database{.circle,}.yml
       - run: bundle exec rake db:create db:migrate
       - run: bundle exec rake


### PR DESCRIPTION
There's currently no guarantee the Elasticsearch process is running when we start the test suite, leading to occasional build failures. It can take a while to initialize the ES container fully. This command will block till ES is available on localhost at the default port, which I believe is our test setup.