### PR TITLE
@jonallured: only allow jwt tokens from trusted apps

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -10,11 +10,15 @@ class ApiController < ApplicationController
 
   def token_match?
     auth_header = request.headers['HTTP_AUTHORIZATION']
-    return false unless auth_header
     token = auth_header.split(' ').last
     secret = Rails.application.secrets.artsy_internal_secret
-    JWT.decode(token, secret)
-  rescue JWT::DecodeError
+    payload = JWT.decode(token, secret).first
+    validate_payload(payload)
+  rescue JWT::DecodeError, NoMethodError
     return false
+  end
+
+  def validate_payload(payload)
+    payload['roles'].split(',').include?('trusted')
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -10,15 +10,16 @@ class ApiController < ApplicationController
 
   def token_match?
     auth_header = request.headers['HTTP_AUTHORIZATION']
+    return false unless auth_header
     token = auth_header.split(' ').last
     secret = Rails.application.secrets.artsy_internal_secret
     payload = JWT.decode(token, secret).first
     validate_payload(payload)
-  rescue JWT::DecodeError, NoMethodError
+  rescue JWT::DecodeError
     return false
   end
 
   def validate_payload(payload)
-    payload['roles'].split(',').include?('trusted')
+    payload['roles']&.split(',')&.include?('trusted')
   end
 end

--- a/spec/graphql/search_spec.rb
+++ b/spec/graphql/search_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe GraphqlController, type: :controller do
   let(:jwt_token) do
     JWT.encode(
-      { aud: Rails.application.secrets.artsy_application_id },
+      { aud: Rails.application.secrets.artsy_application_id, roles: 'trusted' },
       Rails.application.secrets.artsy_internal_secret
     )
   end

--- a/spec/graphql/search_spec.rb
+++ b/spec/graphql/search_spec.rb
@@ -7,11 +7,26 @@ describe GraphqlController, type: :controller do
       Rails.application.secrets.artsy_internal_secret
     )
   end
+  let(:untrusted_jwt_token) do
+    JWT.encode(
+      { aud: Rails.application.secrets.artsy_application_id },
+      Rails.application.secrets.artsy_internal_secret
+    )
+  end
   describe 'execute' do
-    it 'requires a token' do
-      post :execute
-      expect(response.status).to eq 401
-      expect(response.body).to eq 'Access Denied'
+    context 'without auth' do
+      it 'requires a token' do
+        post :execute
+        expect(response.status).to eq 401
+        expect(response.body).to eq 'Access Denied'
+      end
+      it 'requires a trusted role' do
+        auth_headers = { 'Authorization' => "Bearer #{untrusted_jwt_token}" }
+        request.headers.merge! auth_headers
+        post :execute
+        expect(response.status).to eq 401
+        expect(response.body).to eq 'Access Denied'
+      end
     end
     context 'with auth' do
       let(:auth_headers) { { 'Authorization' => "Bearer #{jwt_token}" } }


### PR DESCRIPTION
It turns out gravity has an [Auth API endpoint](https://github.com/artsy/gravity/blob/master/app/api/v1/me_auth_endpoint.rb#L20) that deals out JWT tokens to untrusted apps (like force) with a short expiry. This can theoretically be used to produce valid JWT tokens for Bearden knowing only the Bearden application ID, which is a security problem. 

While the Gravity API endpoint looks like a security hole, it can be useful for some apps who wish to allow access to a set of users from an untrusted app (like Impulse, which wants to allow some Force users access to their conversations inbox data, as Force is an untrusted app in this scheme). 

We've decided it's up to the destination app to validate app roles in its auth if it wishes to restrict access to trusted apps. This is the case with Bearden, so I've added the additional checks in our auth method to ensure that the app which requested the token is trusted. We use 'roles' embedded in the JWT to determine whether an app is trusted (see [gravity code](https://github.com/artsy/gravity/blob/master/app/models/util/application_trust.rb#L14)). 

cc @joeyAghion @mzikherman 