### PR TITLE
Don't raise when the record can't be found

### DIFF
--- a/app/jobs/search_index_job.rb
+++ b/app/jobs/search_index_job.rb
@@ -2,7 +2,7 @@ class SearchIndexJob
   include Sidekiq::Worker
 
   def perform(klass, id)
-    obj = klass.constantize.find(id)
+    obj = klass.constantize.find_by id: id
     return unless obj
     obj.es_index
   end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -12,7 +12,7 @@ module Searchable
     skip_callback(:destroy, :after, :es_delete)
 
     # background indexing
-    after_save :delay_es_index
+    after_commit :delay_es_index
     after_destroy :delay_es_delete
   end
 


### PR DESCRIPTION
The return here only works if we use the `find_by` form, otherwise, `find` will just raise if it can't find the record and you'll never even hit the early return on the next line.

I know this because I was having issues with these jobs while testing #324 locally here on my laptop. This change fixed those jobs from failing, but might expose a different problem. I have a theory that these search indexing jobs are enqueued and then worked too quickly for Postgres. I think I was getting that exception about the record not being found because it was a race condition with the database insert!

If that's true, then this "fix" would actually break our search indexing and what we really need to do is find a way to introduce some delay between insertion and indexing.

Or maybe I'm missing something, but wanted to get master back into a good state while we tinker. Open to other ideas, of course!!