### PR TITLE
Improve API docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,31 +4,34 @@ Bearden implements a GraphQL API.
 
 ### Authentication
 
-Trusted apps may use the Bearden API using [JWT](https://jwt.io/) authentication. You will need to obtain a JWT for Bearden from a Gravity console on Staging.
+Trusted apps may use the Bearden API using [JWT](https://jwt.io/)
+authentication. You will need to obtain a JWT for Bearden from a Gravity console
+on Staging following [the standard process][grav_doc].
 
-```
-~/gravity $  AWS_USER=... AWS_ID=... AWS_SECRET=... rake ow:console[staging]
-Starting remote console... (use Ctrl-D to exit cleanly)
-Loading staging environment (Rails 5.0.3)
-gravity:staging>
-```
+Then you can make API calls like this using [graphlient]:
 
 ```ruby
-app = ClientApplication.where(name: 'Bearden').first
-expires_in = 42.years.from_now
-token = ApplicationTrust.create_for_token_authentication(app, expires_in: expires_in)
-puts token
-```
+url = 'https://bearden-staging.artsy.net' # or production
+token = 'shhh' # paste in token from Gravity
+client = Graphlient::Client.new(url, headers: { 'Authorization' => "Bearer #{token}" })
 
-Save your token in your `.env` file if needed. Once in possession of the token, send it in your requests to Bearden:
+# sanity check
+client.schema
 
-```ruby
-headers = { 'Authorization' => "Bearer #{token}" }
+# search for first 5 modern organizations
+response = client.query { query { search(term: "modern", first: 5) { id; name } } }
+response.data.search.map(&:name)
+ => ["Modern", "Noho Modern", "Katz Modern", "Imitate Modern", "Tate Modern"]
 ```
 
 ### IDE
 
-Use [GraphQL IDE](https://github.com/andev-software/graphql-ide/releases). Create a new project and point the Environment to `http://localhost:5000/api/graphql` with an `Authorization` header value of `Bearer <token>`.
+Use [Graphql IDE][ide]. Create a new project and point the Environment to
+`http://localhost:5000/api/graphql` with an `Authorization` header value of
+`Bearer <token>`.
 
 ![](api/ide.png)
 
+[graphlient]: https://github.com/ashkan18/graphlient
+[grav_doc]: https://github.com/artsy/gravity/blob/master/doc/ApiAuthentication.md#create-an-app-trust-token
+[ide]: https://github.com/andev-software/graphql-ide/releases


### PR DESCRIPTION
I had some trouble today working with the Bearden API while smoke testing #329, so I spent some time improving the API docs. I was never actually able to get GraphQL IDE to work, but [graphlient](https://github.com/ashkan18/graphlient) worked like a charm!