### PR TITLE
Upgrade to latest Postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: circleci/ruby:2.5.0-node
         environment:
           RAILS_ENV: test
-      - image: circleci/postgres:9.6.2-alpine
+      - image: circleci/postgres:10.1-alpine
       - image: circleci/elasticsearch
     steps:
       - run: sudo apt-get install libicu-dev


### PR DESCRIPTION
I think it's time - version 10 has been out for a while and is now GA on Heroku since mid-December. I started with my laptop:

```
$ brew upgrade postgres
```

In the post-upgrade message, there's a command to run that will upgrade your data, I ran that without error. I expected to have to reinstall the pg gem, but rake was green without it.

Next step is upgrading at Heroku, which I'll document next but let's see what happens at Circle.