### PR TITLE
Use Heroku release phase for database migrations

### DIFF
--- a/.circleci/heroku_deploy
+++ b/.circleci/heroku_deploy
@@ -4,8 +4,6 @@ if git remote | grep heroku > /dev/null; then
   git fetch heroku
   heroku pg:backups:capture
   git push --force heroku $CIRCLE_SHA1:master
-  heroku run --exit-code rake db:migrate
-  heroku restart
 else
   exit 0
 fi

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma
 worker: bundle exec sidekiq -c ${DEFAULT_QUEUE_CONCURRENCY} -q default
 export_worker: bundle exec sidekiq -c ${EXPORT_QUEUE_CONCURRENCY} -q export


### PR DESCRIPTION
I hadn't heard of this, but I like this approach much better for ensuring database migrations happen before the dynos are in production.

https://devcenter.heroku.com/articles/release-phase