### PR TITLE
Fix deployment

### DIFF
--- a/.circleci/heroku_setup
+++ b/.circleci/heroku_setup
@@ -8,6 +8,7 @@ else
   exit 0
 fi
 
+npm install -g heroku-cli
 git remote add heroku https://git.heroku.com/$app_name.git
 wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
 mkdir -p /usr/local/lib /usr/local/bin


### PR DESCRIPTION
With the switch to Arty's Ruby image, we can no longer rely on Heroku's CLI being installed for us.