### PR TITLE
Ignore the build and test job on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,10 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build-and-test
+      - build-and-test:
+          filters:
+            branches:
+              ignore: release
       - deploy-staging:
           requires:
             - build-and-test


### PR DESCRIPTION
Oops! Forgot to ignore the build-and-test job when deploying to production, which was the whole point of removing the requirement from that job. 😝 

/cc @starsirius 