### PR TITLE
Use better ES image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         environment:
           RAILS_ENV: test
       - image: circleci/postgres:10.1-alpine
-      - image: circleci/elasticsearch
+      - image: library/elasticsearch:2.4.5-alpine
     steps:
       - run:
           name: Install ICU for charlock_holmes


### PR DESCRIPTION
It appears that CircleCI no longer maintains ES images, so this PR switches to another source.