### PR TITLE
PLATFORM-1044: Update vulnerable gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,7 +388,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.3)
       rack
     rack-test (1.0.0)
@@ -594,4 +594,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
GitHub has notified of us of the following vulnerable gem dependency.

This commit updates the dependency to satisfy the following Common
Vulnerabilities and Exposures (CVE) alerts.

https://github.com/artsy/bearden/network/alerts

- rack (moderate): https://nvd.nist.gov/vuln/detail/CVE-2018-16470,
  https://nvd.nist.gov/vuln/detail/CVE-2018-16471

ticket: https://artsyproduct.atlassian.net/browse/PLATFORM-1044